### PR TITLE
Email bug fix

### DIFF
--- a/src/signup/signup.controller.ts
+++ b/src/signup/signup.controller.ts
@@ -45,6 +45,7 @@ export class SignupController {
     @Query("r") redirect: string | undefined,
     @Res() res
   ) {
+    if (!redirect) redirect = "/auth/me";
     // Validate signupUserDto.
     let validationErrors = undefined;
     if (
@@ -105,6 +106,7 @@ export class SignupController {
     @Query("user") userJwt: string,
     @Res() res
   ) {
+    if (!redirectLink) redirectLink = "/auth/me";
     try {
       const user = await this.signupService.confirmUserSignup(userJwt);
       this.authService.applyJwt(user, res);
@@ -134,6 +136,7 @@ export class SignupController {
     @Query("r") redirectLink: string | undefined,
     @Res() res
   ) {
+    if (!redirectLink) redirectLink = "/auth/me";
     try {
       const userEmail = await this.signupService.resendVerificationEmail(
         req.cookies["accessToken"],

--- a/src/user-auth/user-auth.service.ts
+++ b/src/user-auth/user-auth.service.ts
@@ -26,6 +26,7 @@ export class UserAuthService {
       throw new BadRequestException(
         "Email is required to be a non-empty string"
       );
+    createUserAuth.email = createUserAuth.email.toLowerCase();
     try {
       existingUser = await this.findByEmail(createUserAuth.email);
     } catch (e) {
@@ -75,7 +76,7 @@ export class UserAuthService {
    * @param email Email Address (UserAuth.email)
    */
   async findByEmail(email: string): Promise<UserAuth> {
-    return await this.userAuthModel.findOne({ email });
+    return await this.userAuthModel.findOne({ email: email.toLowerCase() });
   }
 
   /**


### PR DESCRIPTION
Closes #38.

* UserAuthService now turns emails to lowercase when creating or searching for UserAuths
* Added tests for these cases
* Fixed test cases that used `try-catch` statements which missed running the tests in the `catch` block if no error was thrown in `try`