### PR TITLE
Added decorator to extract query param with default value

### DIFF
--- a/src/common/decorators/query-with-default.decorator.ts
+++ b/src/common/decorators/query-with-default.decorator.ts
@@ -1,0 +1,13 @@
+import { createParamDecorator, ExecutionContext } from "@nestjs/common";
+
+export const QueryWithDefault = (
+  key: string,
+  defaultVal: string
+): ParameterDecorator => {
+  return createParamDecorator((data, ctx: ExecutionContext) => {
+    const { key, defaultVal } = data;
+    const request = ctx.switchToHttp().getRequest();
+    const val = request.query[key];
+    return val || defaultVal;
+  })({ key, defaultVal });
+};

--- a/src/login/login.controller.ts
+++ b/src/login/login.controller.ts
@@ -6,8 +6,7 @@ import {
   Req,
   Res,
   UseFilters,
-  UseGuards,
-  Query
+  UseGuards
 } from "@nestjs/common";
 import { GetUserAuth } from "../user-auth/user-auth.decorator";
 import { AuthService } from "../auth/auth.service";
@@ -15,6 +14,7 @@ import { UserAuth } from "../user-auth/interfaces/user-auth.interface";
 import { LoginRootExceptionFilter } from "./filters/login-root-exception.filter";
 import { AuthGuard } from "@nestjs/passport";
 import { LoginProviderExceptionFilter } from "./filters/login-provider-exception.filter";
+import { QueryWithDefault } from "../common/decorators/query-with-default.decorator";
 
 @Controller("login")
 export class LoginController {
@@ -22,10 +22,14 @@ export class LoginController {
 
   @Get("/")
   @Render("login/index")
-  root(@Req() req, @Query("r") redirect: string | undefined) {
+  root(
+    @Req() req,
+    @QueryWithDefault("r", "/auth/me") redirectLink: string | undefined
+  ) {
+    console.log(redirectLink);
     return {
       csrfToken: req.csrfToken(),
-      redirectLink: redirect || "/auth/me"
+      redirectLink
     };
   }
 
@@ -43,10 +47,10 @@ export class LoginController {
   googleLoginCallback(@Req() req, @GetUserAuth() user: UserAuth, @Res() res) {
     // TODO: Add error handling for when user does not exist. That mostly shouldn't happen due to the Google AuthGuard
     this.authService.applyJwt(user, res);
-    const redirect = req.session.redirect;
+    const redirect = req.session.redirect || "/auth/me";
     req.session.redirect = null;
     // TODO: Based on how redirects are done, implement the propagation of the URL from the original request to the callback
-    return res.redirect(redirect || "/auth/me");
+    return res.redirect(redirect);
   }
 
   @Get("facebook")
@@ -62,10 +66,10 @@ export class LoginController {
   facebookLoginCallback(@Req() req, @GetUserAuth() user: UserAuth, @Res() res) {
     // TODO: Add error handling for when user does not exist. That mostly shouldn't happen due to the Facebook AuthGuard
     this.authService.applyJwt(user, res);
-    const redirect = req.session.redirect;
+    const redirect = req.session.redirect || "/auth/me";
     req.session.redirect = null;
     // TODO: Based on how redirects are done, implement the propagation of the URL from the original request to the callback
-    return res.redirect(redirect || "/auth/me");
+    return res.redirect(redirect);
   }
 
   @UseFilters(LoginRootExceptionFilter, LoginProviderExceptionFilter) // Need exception filter to handle guard fails (maintain order).
@@ -73,11 +77,11 @@ export class LoginController {
   @Post("/")
   loginEmailAndPassword(
     @GetUserAuth() user: UserAuth,
-    @Query("r") redirect: string | undefined,
+    @QueryWithDefault("r", "/auth/me") redirect: string | undefined,
     @Res() res
   ) {
     this.authService.applyJwt(user, res);
     // TODO: make sure the redirect is only a relative url and cannot be a URL outside (like https://google.com)
-    return res.redirect(redirect || "/auth/me");
+    return res.redirect(redirect);
   }
 }

--- a/src/signup/signup.controller.ts
+++ b/src/signup/signup.controller.ts
@@ -13,6 +13,7 @@ import { SignupUserDto } from "./dto/signup-user.dto";
 import { SignupService } from "./signup.service";
 import { ValidatorService } from "../validator/validator.service";
 import { AuthService } from "../auth/auth.service";
+import { QueryWithDefault } from "../common/decorators/query-with-default.decorator";
 
 @Controller("signup")
 export class SignupController {
@@ -31,10 +32,13 @@ export class SignupController {
 
   @Get()
   @Render("signup/index")
-  root(@Req() req, @Query("r") redirect: string | undefined) {
+  root(
+    @Req() req,
+    @QueryWithDefault("r", "/auth/me") redirectLink: string | undefined
+  ) {
     return {
       csrfToken: req.csrfToken(),
-      redirectLink: redirect || "/auth/me"
+      redirectLink
     };
   }
 
@@ -42,10 +46,9 @@ export class SignupController {
   async signupUserEmailAndPassword(
     @Req() req,
     @Body() signupUserDto: SignupUserDto,
-    @Query("r") redirect: string | undefined,
+    @QueryWithDefault("r", "/auth/me") redirectLink: string | undefined,
     @Res() res
   ) {
-    if (!redirect) redirect = "/auth/me";
     // Validate signupUserDto.
     let validationErrors = undefined;
     if (
@@ -71,7 +74,7 @@ export class SignupController {
     if (validationErrors)
       return res.status(400).render("signup/index", {
         csrfToken: req.csrfToken(),
-        redirectLink: redirect,
+        redirectLink,
         emailPrefill: signupUserDto.email,
         ...validationErrors
       });
@@ -79,7 +82,7 @@ export class SignupController {
     try {
       const user = await this.signupService.signupUserEmailAndPassword(
         signupUserDto,
-        redirect
+        redirectLink
       );
       return res.render("signup/verification-email-sent", {
         userEmail: user.email
@@ -89,7 +92,7 @@ export class SignupController {
       if (e instanceof ConflictException)
         return res.status(409).render("signup/index", {
           csrfToken: req.csrfToken(),
-          redirectLink: redirect,
+          redirectLink,
           emailPrefill: signupUserDto.email,
           emailError: this.controllerErrors.userExists
         });
@@ -102,11 +105,10 @@ export class SignupController {
   @Get("verify")
   async confirmSignup(
     @Req() req,
-    @Query("r") redirectLink: string | undefined,
+    @QueryWithDefault("r", "/auth/me") redirectLink: string | undefined,
     @Query("user") userJwt: string,
     @Res() res
   ) {
-    if (!redirectLink) redirectLink = "/auth/me";
     try {
       const user = await this.signupService.confirmUserSignup(userJwt);
       this.authService.applyJwt(user, res);
@@ -133,10 +135,9 @@ export class SignupController {
    */
   async resendVerificationEmail(
     @Req() req,
-    @Query("r") redirectLink: string | undefined,
+    @QueryWithDefault("r", "/auth/me") redirectLink: string | undefined,
     @Res() res
   ) {
-    if (!redirectLink) redirectLink = "/auth/me";
     try {
       const userEmail = await this.signupService.resendVerificationEmail(
         req.cookies["accessToken"],


### PR DESCRIPTION
@geooot Saw some inconsistencies in the signup controller where some endpoints used the default redirect link value (for an undefined redirect) and some didn't. Thought we could just replace the `@Query()` decorator with a custom one that takes in a default value.

Let me know what you think.