### PR TITLE
Switched CI to custom comment action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Publish URL in comment
         uses: phulsechinmay/rewritable-pr-comment@v0.2
         with:
-          msg: |
+          message: |
             **✅ Jest Unit Test(s) passed for commit [`${{ steps.results.outputs.short-commit }}`](https://github.com/tamu-datathon-org/gatekeeper/commit/${{ github.event.after }})**
             Link to code coverage report: ${{ steps.publisher.outputs.preview-url }}
             

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           echo "::set-output name=short-commit::$(git rev-parse --short ${{ github.event.after }})"
       - name: Publish Jest Failure Output
         if: failure()
-        uses: phulsechinmay/rewriteable-pr-comment@v0.2
+        uses: phulsechinmay/rewritable-pr-comment@v0.2
         with:
           message: |
             **❌ Jest Unit Test(s) failed for commit [`${{ steps.results.outputs.short-commit }}`](https://github.com/tamu-datathon-org/gatekeeper/commit/${{ github.event.after }})**
@@ -140,7 +140,7 @@ jobs:
           echo "::set-output name=coverage-results::$report_stdout"
           echo "::set-output name=short-commit::$(git rev-parse --short ${{ github.event.after }})"
       - name: Publish URL in comment
-        uses: phulsechinmay/rewriteable-pr-comment@v0.2
+        uses: phulsechinmay/rewritable-pr-comment@v0.2
         with:
           msg: |
             **✅ Jest Unit Test(s) passed for commit [`${{ steps.results.outputs.short-commit }}`](https://github.com/tamu-datathon-org/gatekeeper/commit/${{ github.event.after }})**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,9 @@ jobs:
           echo "::set-output name=short-commit::$(git rev-parse --short ${{ github.event.after }})"
       - name: Publish Jest Failure Output
         if: failure()
-        uses: unsplash/comment-on-pr@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: phulsechinmay/rewriteable-pr-comment@v0.2
         with:
-          msg: |
+          message: |
             **❌ Jest Unit Test(s) failed for commit [`${{ steps.results.outputs.short-commit }}`](https://github.com/tamu-datathon-org/gatekeeper/commit/${{ github.event.after }})**
 
             <details><summary>Jest stderr:</summary>
@@ -97,7 +95,8 @@ jobs:
             </p>
             </details>
 
-          check_for_duplicate_msg: false
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_IDENTIFIER: "ci-unit-tests-comment"
       - name: Upload Coverage Artifact
         if: success() || failure()
         uses: actions/upload-artifact@v1
@@ -141,9 +140,7 @@ jobs:
           echo "::set-output name=coverage-results::$report_stdout"
           echo "::set-output name=short-commit::$(git rev-parse --short ${{ github.event.after }})"
       - name: Publish URL in comment
-        uses: unsplash/comment-on-pr@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: phulsechinmay/rewriteable-pr-comment@v0.2
         with:
           msg: |
             **✅ Jest Unit Test(s) passed for commit [`${{ steps.results.outputs.short-commit }}`](https://github.com/tamu-datathon-org/gatekeeper/commit/${{ github.event.after }})**
@@ -169,4 +166,5 @@ jobs:
             </p>
             </details>
 
-          check_for_duplicate_msg: false
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_IDENTIFIER: "ci-unit-tests-comment"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ npm run start:dev
 $ npm run start:prod
 ```
 
-## :white_check_mark: Test
+## :white_check_mark: Testing
 ```bash
 # unit tests
 $ npm run test


### PR DESCRIPTION
**Guess what?** Your boy made a custom Github Action for a rewriteable PR Comment.

Was there another way around it? *Probably*. 
Did I over-engineer it? *Maybe*.
Am I going to live in denial about it? **You bet.**

Closes #51 