### PR TITLE
Auth Redirects and Using host and origin headers.

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -10,7 +10,7 @@ MAILGUN_DEFAULT_EMAIL="connect@tamudatathon.com"
 MAILGUN_DEFAULT_NAME="TAMU Datathon"
 MAILGUN_API_KEY=enter_apikey_here
 
-GATEKEEPER_DOMAIN = enter_domain_here
+DEFAULT_GATEKEEPER_ORIGIN = "https://tamudatathon.com"
 
 # Check https://github.com/auth0/node-jsonwebtoken#jwtsignpayload-secretorprivatekey-options-callback
 CONFIRMATION_JWT_EXPIRATION=2h 

--- a/.env.test
+++ b/.env.test
@@ -20,10 +20,10 @@ AUTH_JWT_EXPIRATION=14d
 
 GOOGLE_OAUTH_CLIENT_ID="TEST_ID"
 GOOGLE_OAUTH_CLIENT_SECRET="TEST_SECRET"
-GOOGLE_OAUTH_CALLBACK_URL="http://localhost:4000/auth/login/google/callback"
+GOOGLE_OAUTH_CALLBACK_URL="/auth/login/google/callback"
 
 FACEBOOK_OAUTH_APP_ID="TEST_ID"
 FACEBOOK_OAUTH_APP_SECRET="TEST_SECRET"
-FACEBOOK_OAUTH_CALLBACK_URL="http://localhost:4000/auth/login/facebook/callback"
+FACEBOOK_OAUTH_CALLBACK_URL="/auth/login/facebook/callback"
 
 GATEKEEPER_INTEGRATION_SECRET=another_randomly_generated_string

--- a/.env.test
+++ b/.env.test
@@ -7,7 +7,7 @@ MAILGUN_DEFAULT_EMAIL="connect@tamudatathon.com"
 MAILGUN_DEFAULT_NAME="TAMU Datathon"
 MAILGUN_API_KEY="TEST_API_KEY"
 
-GATEKEEPER_DOMAIN = "http://localhost:4000"
+DEFAULT_GATEKEEPER_ORIGIN = "https://tamudatathon.com"
 CONFIRMATION_JWT_EXPIRATION=2h
 
 EMAIL_TEMPLATES_DIR = "src/mail/templates/"

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -18,7 +18,7 @@ const proxyToLocalhost = (req, res, next) => {
       url = path.slice(1).length >= 1 ? path.slice(1).join("/") : "";
     }
     req.originalUrl = url;
-    req.headers["host"] = "tamudatathon.com";
+    //req.headers["host"] = "tamudatathon.com"; // Hosts need to be preserved for oauth strategies
     const target = `http://localhost:3000/${url || ""}`;
     const config = {
       target,

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -5,6 +5,7 @@ import { UserAuthService } from "./user-auth/user-auth.service";
 import { GetUser } from "./user/user-auth.decorator";
 import { User } from "./user/interfaces/user.interface";
 import { AuthService } from "./auth/auth.service";
+import { QueryWithDefault } from "./common/decorators/query-with-default.decorator";
 
 @Controller()
 export class AppController {
@@ -20,9 +21,9 @@ export class AppController {
 
   @UseGuards(AuthGuard("jwt"))
   @Get("/logout")
-  async logout(@GetUser() user: User, @Res() res) {
+  async logout(@GetUser() user: User, @QueryWithDefault("r", "/auth/login") redirect, @Res() res) {
     await this.authService.deauthorizeUser(user, res);
-    return res.redirect("/auth/login");
+    return res.redirect(redirect);
   }
 
   // THESE ENDPOINTS BELOW ARE TEMPORARY, REMOVE LATER

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -21,7 +21,11 @@ export class AppController {
 
   @UseGuards(AuthGuard("jwt"))
   @Get("/logout")
-  async logout(@GetUser() user: User, @QueryWithDefault("r", "/auth/login") redirect, @Res() res) {
+  async logout(
+    @GetUser() user: User,
+    @QueryWithDefault("r", "/auth/login") redirect,
+    @Res() res
+  ) {
     await this.authService.deauthorizeUser(user, res);
     return res.redirect(redirect);
   }

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,10 +1,6 @@
 export const Constants = {
   defaultRedirect: "/",
-  validHosts: [
-    "localhost:4000",
-    "localhost:8080",
-    "tamudatathon.com"
-  ],
+  validHosts: ["tamudatathon.com"], // Localhost is considered valid by default.
   validSubdomainHosts: [
     "tamudatathon.com",
     "tamudatathon.now.sh",
@@ -12,4 +8,4 @@ export const Constants = {
   ]
 };
 
-export const validDomainRegex = /^((?:(?:(?:\w[\.\-\+]?)*)\w)+)((?:(?:(?:\w[\.\-\+]?){0,62})\w)+)\.(\w{2,6})$/;
+export const validDomainRegex = /^((?:(?:(?:\w[.\-+]?)*)\w)+)((?:(?:(?:\w[.\-+]?){0,62})\w)+)\.(\w{2,6})$/;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,9 +1,15 @@
 export const Constants = {
   defaultRedirect: "/",
-  validHosts: ["localhost", "tamudatathon.com"],
+  validHosts: [
+    "localhost:4000",
+    "localhost:8080",
+    "tamudatathon.com"
+  ],
   validSubdomainHosts: [
     "tamudatathon.com",
     "tamudatathon.now.sh",
     "tamudatathon.vercel.app"
   ]
 };
+
+export const validDomainRegex = /^((?:(?:(?:\w[\.\-\+]?)*)\w)+)((?:(?:(?:\w[\.\-\+]?){0,62})\w)+)\.(\w{2,6})$/;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,0 +1,9 @@
+export const Constants = {
+  defaultRedirect: "/",
+  validHosts: ["localhost", "tamudatathon.com"],
+  validSubdomainHosts: [
+    "tamudatathon.com",
+    "tamudatathon.now.sh",
+    "tamudatathon.vercel.app"
+  ]
+};

--- a/src/common/decorators/query-with-default.decorator.ts
+++ b/src/common/decorators/query-with-default.decorator.ts
@@ -1,9 +1,9 @@
 import { createParamDecorator, ExecutionContext } from "@nestjs/common";
-import { Defaults } from "../defaults";
+import { Constants } from "../constants";
 
 export const QueryWithDefault = (
   key: string,
-  defaultVal: string = Defaults.redirect
+  defaultVal: string = Constants.defaultRedirect
 ): ParameterDecorator => {
   return createParamDecorator((data, ctx: ExecutionContext) => {
     const { key, defaultVal } = data;

--- a/src/common/decorators/validated-host.decorator.ts
+++ b/src/common/decorators/validated-host.decorator.ts
@@ -1,0 +1,28 @@
+import { createParamDecorator, ExecutionContext } from "@nestjs/common";
+import { Constants } from "../constants";
+
+export const isHostValid = (
+  host: string,
+  validHosts: string[] = Constants.validHosts,
+  validSubdomainHosts: string[] = Constants.validSubdomainHosts
+): boolean => {
+  if (validHosts.some(val => host === val)) return true;
+
+  // Check if host is a subdomain of any validSubdomainHosts.
+  const hostTokens = host.split(".");
+  return validSubdomainHosts.some((subdomainHost: string) => {
+    const subdomainHostTokens = subdomainHost.split(".");
+    if (hostTokens.length < subdomainHostTokens.length) return false;
+    return hostTokens.slice(hostTokens.length - subdomainHostTokens.length).join(".") === subdomainHost;
+  });
+};
+
+export const ValidatedHost = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    const host = request.headers["host"];
+    if (!host || !isHostValid(host))
+      return process.env.DEFAULT_GATEKEEPER_ORIGIN;
+    return host;
+  }
+);

--- a/src/common/decorators/validated-host.decorator.ts
+++ b/src/common/decorators/validated-host.decorator.ts
@@ -1,19 +1,17 @@
 import { createParamDecorator, ExecutionContext } from "@nestjs/common";
-import { Constants } from "../constants";
+import { Constants, validDomainRegex } from "../constants";
 
 export const isHostValid = (
   host: string,
   validHosts: string[] = Constants.validHosts,
   validSubdomainHosts: string[] = Constants.validSubdomainHosts
 ): boolean => {
+  if (!validDomainRegex.test(host)) return false;
   if (validHosts.some(val => host === val)) return true;
 
   // Check if host is a subdomain of any validSubdomainHosts.
-  const hostTokens = host.split(".");
   return validSubdomainHosts.some((subdomainHost: string) => {
-    const subdomainHostTokens = subdomainHost.split(".");
-    if (hostTokens.length < subdomainHostTokens.length) return false;
-    return hostTokens.slice(hostTokens.length - subdomainHostTokens.length).join(".") === subdomainHost;
+    return host.endsWith("." + subdomainHost);
   });
 };
 

--- a/src/common/decorators/validated-host.decorator.ts
+++ b/src/common/decorators/validated-host.decorator.ts
@@ -6,6 +6,7 @@ export const isHostValid = (
   validHosts: string[] = Constants.validHosts,
   validSubdomainHosts: string[] = Constants.validSubdomainHosts
 ): boolean => {
+  if (host.split(":")[0] === "localhost") return true;
   if (!validDomainRegex.test(host)) return false;
   if (validHosts.some(val => host === val)) return true;
 

--- a/src/common/decorators/validated-host.spec.ts
+++ b/src/common/decorators/validated-host.spec.ts
@@ -1,0 +1,71 @@
+import { isHostValid } from "./validated-host.decorator";
+
+describe("isHostValid", () => {
+  it("Should return TRUE for an exact match to a host", () => {
+    const result = isHostValid(
+      "test.com",
+      ["test.com", "hello.com"],
+      ["google.com"]
+    );
+    expect(result).toBe(true);
+  });
+
+  it("Should return TRUE for a subdomain match to a subdomainHost", () => {
+    const result = isHostValid(
+      "something.google.com",
+      ["test.com", "hello.com"],
+      ["google.com"]
+    );
+    expect(result).toBe(true);
+  });
+
+  it("Should return TRUE for localhost", () => {
+    const result = isHostValid(
+      "localhost",
+      ["test.com", "hello.com"],
+      ["google.com"]
+    );
+    expect(result).toBe(true);
+  });
+
+  it("Should return TRUE for localhost with a port", () => {
+    const result = isHostValid(
+      "localhost:8989",
+      ["test.com", "hello.com"],
+      ["google.com"]
+    );
+    expect(result).toBe(true);
+  });
+
+  it("Should return FALSE for an invalid host", () => {
+    const result = isHostValid(
+      "thisisinvalid",
+      ["test.com", "hello.com", "thisisinvalid.com"],
+      ["google.com"]
+    );
+    expect(result).toBe(false);
+  });
+
+  it("Should return FALSE for a host that matches nothing", () => {
+    const result = isHostValid(
+      "doesnotmatchanything.com",
+      ["test.com", "hello.com"],
+      ["google.com"]
+    );
+    expect(result).toBe(false);
+  });
+
+  it("Should return FALSE for a direct match to a subdomainHost (and nothing else)", () => {
+    const result = isHostValid(
+      "google.com",
+      ["test.com", "hello.com"],
+      ["google.com"]
+    );
+    expect(result).toBe(false);
+  });
+
+  it("Should use default validHosts and validSubdomainhosts when not provided", () => {
+    const result = isHostValid("tamudatathon.com");
+    expect(result).toBe(true);
+  });
+});

--- a/src/common/defaults.ts
+++ b/src/common/defaults.ts
@@ -1,3 +1,0 @@
-export const Defaults = {
-  redirect: "/"
-};

--- a/src/galaxy-integrations/decorators/redirect-galaxy-integration.decorator.ts
+++ b/src/galaxy-integrations/decorators/redirect-galaxy-integration.decorator.ts
@@ -3,7 +3,7 @@ import {
   DefaultGalaxyIntegrations,
   GatekeeperGalaxyIntegration
 } from "../galaxy-integrations";
-import { Defaults } from "../../common/defaults";
+import { Constants } from "../../common/constants";
 
 /**
  * Returns the the longest string in the given list that is a prefix of the given key.
@@ -46,7 +46,7 @@ export const getLongestMatchingPrefix = (key: string, prefixes: string[]) => {
 export const RedirectGalaxyIntegration = createParamDecorator(
   (data: unknown, ctx: ExecutionContext) => {
     const request = ctx.switchToHttp().getRequest();
-    const redirectPath = request.query?.r || Defaults.redirect;
+    const redirectPath = request.query?.r || Constants.defaultRedirect;
 
     // Use default gatekeeper pathPrefix if no matching prefix.
     const longestPathPrefix =

--- a/src/login/filters/login-root-exception.filter.ts
+++ b/src/login/filters/login-root-exception.filter.ts
@@ -8,7 +8,7 @@ import {
 } from "@nestjs/common";
 import { Response } from "express";
 import { UserNotVerifiedException } from "../../auth/exceptions/user-not-verified.exception";
-import { Defaults } from "../../common/defaults";
+import { Constants } from "../../common/constants";
 
 @Catch(HttpException)
 export class LoginRootExceptionFilter implements ExceptionFilter {
@@ -35,7 +35,7 @@ export class LoginRootExceptionFilter implements ExceptionFilter {
       return response
         .status(401)
         .render("signup/resend-verification-email.ejs", {
-          redirectLink: request.query.r || Defaults.redirect
+          redirectLink: request.query.r || Constants.defaultRedirect
         });
     }
 

--- a/src/login/login.controller.ts
+++ b/src/login/login.controller.ts
@@ -17,7 +17,7 @@ import { User } from "../user/interfaces/user.interface";
 import { GetUser } from "../user/user-auth.decorator";
 import { RedirectGalaxyIntegration } from "../galaxy-integrations/decorators/redirect-galaxy-integration.decorator";
 import { GalaxyIntegrationConfig } from "../galaxy-integrations/interfaces/galaxy-integration";
-import { Defaults } from "../common/defaults";
+import { Constants } from "../common/constants";
 
 @Controller("login")
 export class LoginController {
@@ -51,7 +51,7 @@ export class LoginController {
   async googleLoginCallback(@Req() req, @GetUser() user: User, @Res() res) {
     // TODO: Add error handling for when user does not exist. That mostly shouldn't happen due to the Google AuthGuard
     await this.authService.authorizeUser(user, res);
-    const redirect = req.session.redirect || Defaults.redirect;
+    const redirect = req.session.redirect || Constants.defaultRedirect;
     req.session.redirect = null;
     // TODO: Based on how redirects are done, implement the propagation of the URL from the original request to the callback
     return res.redirect(redirect);
@@ -70,7 +70,7 @@ export class LoginController {
   async facebookLoginCallback(@Req() req, @GetUser() user: User, @Res() res) {
     // TODO: Add error handling for when user does not exist. That mostly shouldn't happen due to the Facebook AuthGuard
     await this.authService.authorizeUser(user, res);
-    const redirect = req.session.redirect || Defaults.redirect;
+    const redirect = req.session.redirect || Constants.defaultRedirect;
     req.session.redirect = null;
     // TODO: Based on how redirects are done, implement the propagation of the URL from the original request to the callback
     return res.redirect(redirect);

--- a/src/signup/signup.controller.spec.ts
+++ b/src/signup/signup.controller.spec.ts
@@ -118,6 +118,7 @@ describe("Signup Controller", () => {
       signupUserDto,
       "/app/me",
       GatekeeperGalaxyIntegration,
+      "https://tamudatathon.com",
       response.new()
     );
     expect(params.verificationPageSubtext).toBe(
@@ -139,6 +140,7 @@ describe("Signup Controller", () => {
       signupUserDto,
       "/app/me",
       GatekeeperGalaxyIntegration,
+      "https://tamudatathon.com",
       response.new()
     );
     expect(response.code).toBe(409);
@@ -161,6 +163,7 @@ describe("Signup Controller", () => {
       signupUserDto,
       "/app/me",
       GatekeeperGalaxyIntegration,
+      "https://tamudatathon.com",
       response.new()
     );
     expect(response.code).toBe(400);
@@ -182,6 +185,7 @@ describe("Signup Controller", () => {
       signupUserDto,
       "/app/me",
       GatekeeperGalaxyIntegration,
+      "https://tamudatathon.com",
       response.new()
     );
     expect(response.code).toBe(400);
@@ -203,6 +207,7 @@ describe("Signup Controller", () => {
       signupUserDto,
       "/app/me",
       GatekeeperGalaxyIntegration,
+      "https://tamudatathon.com",
       response.new()
     );
     expect(response.code).toBe(400);
@@ -227,6 +232,7 @@ describe("Signup Controller", () => {
       signupUserDto,
       "/app/me",
       GatekeeperGalaxyIntegration,
+      "https://tamudatathon.com",
       response.new()
     );
     expect(response.code).toBe(400);
@@ -251,6 +257,7 @@ describe("Signup Controller", () => {
       signupUserDto,
       "/app/me",
       GatekeeperGalaxyIntegration,
+      "https://tamudatathon.com",
       response.new()
     );
     expect(response.code).toBe(400);
@@ -310,6 +317,7 @@ describe("Signup Controller", () => {
         cookies: { accessToken: "test.user.jwt" }
       },
       "/app/me",
+      "https://tamudatathon.com",
       response.new()
     );
 
@@ -330,6 +338,7 @@ describe("Signup Controller", () => {
         cookies: { accessToken: "test.user.jwt" }
       },
       "/app/me",
+      "https://tamudatathon.com",
       response.new()
     );
 
@@ -350,6 +359,7 @@ describe("Signup Controller", () => {
         cookies: { accessToken: "test.user.jwt" }
       },
       "/app/me",
+      "https://tamudatathon.com",
       response.new()
     );
 

--- a/src/signup/signup.controller.ts
+++ b/src/signup/signup.controller.ts
@@ -53,7 +53,7 @@ export class SignupController {
     @Body() signupUserDto: SignupUserDto,
     @QueryWithDefault("r", "/") redirectLink: string | undefined,
     @RedirectGalaxyIntegration() integrationConfig: GalaxyIntegrationConfig,
-    @ValidatedHost() origin,
+    @ValidatedHost() host,
     @Res() res
   ) {
     // Validate signupUserDto.
@@ -89,7 +89,7 @@ export class SignupController {
     try {
       const user = await this.signupService.signupUserEmailAndPassword(
         signupUserDto,
-        origin,
+        host,
         redirectLink
       );
       return res.render("signup/verification-email-sent", {
@@ -144,13 +144,13 @@ export class SignupController {
   async resendVerificationEmail(
     @Req() req,
     @QueryWithDefault("r") redirectLink: string | undefined,
-    @ValidatedHost() origin,
+    @ValidatedHost() host,
     @Res() res
   ) {
     try {
       const userEmail = await this.signupService.resendVerificationEmail(
         req.cookies["accessToken"],
-        origin,
+        host,
         redirectLink
       );
       return res.render("signup/verification-email-sent", {

--- a/src/signup/signup.controller.ts
+++ b/src/signup/signup.controller.ts
@@ -7,8 +7,7 @@ import {
   Body,
   ConflictException,
   Res,
-  Query,
-  Headers
+  Query
 } from "@nestjs/common";
 import { SignupUserDto } from "./dto/signup-user.dto";
 import { SignupService } from "./signup.service";
@@ -17,6 +16,7 @@ import { AuthService } from "../auth/auth.service";
 import { QueryWithDefault } from "../common/decorators/query-with-default.decorator";
 import { RedirectGalaxyIntegration } from "../galaxy-integrations/decorators/redirect-galaxy-integration.decorator";
 import { GalaxyIntegrationConfig } from "../galaxy-integrations/interfaces/galaxy-integration";
+import { ValidatedHost } from "../common/decorators/validated-host.decorator";
 
 @Controller("signup")
 export class SignupController {
@@ -53,7 +53,7 @@ export class SignupController {
     @Body() signupUserDto: SignupUserDto,
     @QueryWithDefault("r", "/") redirectLink: string | undefined,
     @RedirectGalaxyIntegration() integrationConfig: GalaxyIntegrationConfig,
-    @Headers("origin") origin,
+    @ValidatedHost() origin,
     @Res() res
   ) {
     // Validate signupUserDto.
@@ -144,7 +144,7 @@ export class SignupController {
   async resendVerificationEmail(
     @Req() req,
     @QueryWithDefault("r") redirectLink: string | undefined,
-    @Headers("origin") origin,
+    @ValidatedHost() origin,
     @Res() res
   ) {
     try {

--- a/src/signup/signup.controller.ts
+++ b/src/signup/signup.controller.ts
@@ -7,7 +7,8 @@ import {
   Body,
   ConflictException,
   Res,
-  Query
+  Query,
+  Headers
 } from "@nestjs/common";
 import { SignupUserDto } from "./dto/signup-user.dto";
 import { SignupService } from "./signup.service";
@@ -52,6 +53,7 @@ export class SignupController {
     @Body() signupUserDto: SignupUserDto,
     @QueryWithDefault("r", "/") redirectLink: string | undefined,
     @RedirectGalaxyIntegration() integrationConfig: GalaxyIntegrationConfig,
+    @Headers("origin") origin,
     @Res() res
   ) {
     // Validate signupUserDto.
@@ -87,6 +89,7 @@ export class SignupController {
     try {
       const user = await this.signupService.signupUserEmailAndPassword(
         signupUserDto,
+        origin,
         redirectLink
       );
       return res.render("signup/verification-email-sent", {
@@ -141,11 +144,13 @@ export class SignupController {
   async resendVerificationEmail(
     @Req() req,
     @QueryWithDefault("r") redirectLink: string | undefined,
+    @Headers("origin") origin,
     @Res() res
   ) {
     try {
       const userEmail = await this.signupService.resendVerificationEmail(
         req.cookies["accessToken"],
+        origin,
         redirectLink
       );
       return res.render("signup/verification-email-sent", {

--- a/src/signup/signup.service.spec.ts
+++ b/src/signup/signup.service.spec.ts
@@ -80,7 +80,11 @@ describe("SignupService", () => {
 
     const sendEmailFunc = jest.spyOn(mailService, "sendTemplatedEmail");
 
-    const user = await service.signupUserEmailAndPassword(signupPayload, "/");
+    const user = await service.signupUserEmailAndPassword(
+      signupPayload,
+      "https://tamudatathon.com",
+      "/"
+    );
     expect(user).toBeDefined();
     expect(user.email).toBe(signupPayload.email);
     expect(sendEmailFunc).toHaveBeenCalled();
@@ -97,7 +101,11 @@ describe("SignupService", () => {
       throw new ConflictException();
     });
 
-    const promise = service.signupUserEmailAndPassword(signupPayload, "/");
+    const promise = service.signupUserEmailAndPassword(
+      signupPayload,
+      "https://tamudatathon.com",
+      "/"
+    );
     await expect(promise).rejects.toThrow(ConflictException);
   });
 
@@ -112,7 +120,11 @@ describe("SignupService", () => {
       throw new BadRequestException();
     });
 
-    const promise = service.signupUserEmailAndPassword(signupPayload, "/");
+    const promise = service.signupUserEmailAndPassword(
+      signupPayload,
+      "https://tamudatathon.com",
+      "/"
+    );
     await expect(promise).rejects.toThrow(BadRequestException);
   });
 
@@ -127,7 +139,11 @@ describe("SignupService", () => {
       throw new BadRequestException();
     });
 
-    const promise = service.signupUserEmailAndPassword(signupPayload, "/");
+    const promise = service.signupUserEmailAndPassword(
+      signupPayload,
+      "https://tamudatathon.com",
+      "/"
+    );
     await expect(promise).rejects.toThrow(BadRequestException);
   });
 
@@ -255,7 +271,11 @@ describe("SignupService", () => {
     });
     const sendEmailFunc = jest.spyOn(mailService, "sendTemplatedEmail");
 
-    const userEmail = await service.resendVerificationEmail(userJwt, "/app/me");
+    const userEmail = await service.resendVerificationEmail(
+      userJwt,
+      "https://tamudatathon.com",
+      "/app/me"
+    );
     expect(userEmail).toBe("testy@mctestface.com");
     expect(sendEmailFunc).toHaveBeenCalled();
   });
@@ -270,7 +290,11 @@ describe("SignupService", () => {
       return null; // UserAuthService returns null when user does not exist.
     });
 
-    const promise = service.resendVerificationEmail(userJwt, "/app/me");
+    const promise = service.resendVerificationEmail(
+      userJwt,
+      "https://tamudatathon.com",
+      "/app/me"
+    );
     await expect(promise).rejects.toThrow("Invalid user");
   });
 
@@ -287,7 +311,11 @@ describe("SignupService", () => {
       } as UserAuth;
     });
 
-    const promise = service.resendVerificationEmail(userJwt, "/app/me");
+    const promise = service.resendVerificationEmail(
+      userJwt,
+      "https://tamudatathon.com",
+      "/app/me"
+    );
     await expect(promise).rejects.toThrow("User is already verified");
   });
 });

--- a/src/signup/signup.service.ts
+++ b/src/signup/signup.service.ts
@@ -18,13 +18,12 @@ export class SignupService {
     private readonly jwtService: JwtService
   ) {}
 
-
   private createOriginFromHost(host: string) {
     let scheme = "https";
     if (host.startsWith("localhost")) {
       scheme = "http";
     }
-    return `${scheme}://${host}`
+    return `${scheme}://${host}`;
   }
 
   private getConfirmationUrl(
@@ -55,11 +54,7 @@ export class SignupService {
       subject: "Activate your account!",
       templateFile: "email-confirmation.ejs",
       templateParams: {
-        confirmationLink: this.getConfirmationUrl(
-          userEmail,
-          host,
-          redirectLink
-        )
+        confirmationLink: this.getConfirmationUrl(userEmail, host, redirectLink)
       } /* TODO: Update when email-confirmation is implemented */
     });
   }

--- a/src/signup/signup.service.ts
+++ b/src/signup/signup.service.ts
@@ -18,14 +18,21 @@ export class SignupService {
     private readonly jwtService: JwtService
   ) {}
 
-  private getConfirmationUrl(email: string, origin: string, redirectLink: string) {
+  private getConfirmationUrl(
+    email: string,
+    origin: string,
+    redirectLink: string
+  ) {
     const userJwt = this.jwtService.sign(
       { email },
       {
         expiresIn: process.env.CONFIRMATION_JWT_EXPIRATION
       }
     );
-    const confirmationLink = `${origin || process.env.DEFAULT_GATEKEEPER_ORIGIN}${this.confirmationPath}?user=${userJwt}&r=${redirectLink}`;
+    const confirmationLink = `${origin ||
+      process.env.DEFAULT_GATEKEEPER_ORIGIN}${
+      this.confirmationPath
+    }?user=${userJwt}&r=${redirectLink}`;
     return encodeURI(confirmationLink);
   }
 
@@ -39,7 +46,11 @@ export class SignupService {
       subject: "Activate your account!",
       templateFile: "email-confirmation.ejs",
       templateParams: {
-        confirmationLink: this.getConfirmationUrl(userEmail, origin, redirectLink)
+        confirmationLink: this.getConfirmationUrl(
+          userEmail,
+          origin,
+          redirectLink
+        )
       } /* TODO: Update when email-confirmation is implemented */
     });
   }


### PR DESCRIPTION
Closes #70, Closes #72.

* OAuth callbacks use the `Host` header value, thus the proxy cannot rewrite that header anymore.
* Verification link generation uses the `Origin` header to create the link, and falls back on the `DEFAULT_GATEKEEPER_ORIGIN` if the header isn't present.
* Logout now accepts a redirect query param