### PR TITLE
Reset password functionality

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { APP_FILTER } from "@nestjs/core";
 import { GlobalHttpExceptionFilter } from "./common/filters/global-http-exception.filter";
 import { EventModule } from "./event/event.module";
 import { AttendedEventModule } from "./attended-event/attended-event.module";
+import { ResetPasswordModule } from './reset-password/reset-password.module';
 
 @Module({
   imports: [
@@ -24,7 +25,8 @@ import { AttendedEventModule } from "./attended-event/attended-event.module";
     UserModule,
     LoginModule,
     EventModule,
-    AttendedEventModule
+    AttendedEventModule,
+    ResetPasswordModule
   ],
   controllers: [AppController],
   providers: [

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,7 +12,7 @@ import { APP_FILTER } from "@nestjs/core";
 import { GlobalHttpExceptionFilter } from "./common/filters/global-http-exception.filter";
 import { EventModule } from "./event/event.module";
 import { AttendedEventModule } from "./attended-event/attended-event.module";
-import { ResetPasswordModule } from './reset-password/reset-password.module';
+import { ResetPasswordModule } from "./reset-password/reset-password.module";
 
 @Module({
   imports: [

--- a/src/auth/auth-link-generator.service.ts
+++ b/src/auth/auth-link-generator.service.ts
@@ -3,9 +3,7 @@ import { JwtService } from "@nestjs/jwt";
 
 @Injectable()
 export class AuthLinkGeneratorService {
-  constructor(
-    private readonly jwtService: JwtService
-  ) {}
+  constructor(private readonly jwtService: JwtService) {}
 
   private createOriginFromHost(host: string) {
     if (host.startsWith("https://") || host.startsWith("http://")) return host;
@@ -16,7 +14,12 @@ export class AuthLinkGeneratorService {
     return `${scheme}://${host}`;
   }
 
-  getLinkWithUserJwt(email: string, host: string, path: string = "/", redirectLink: string) {
+  getLinkWithUserJwt(
+    email: string,
+    host: string,
+    path = "/",
+    redirectLink: string
+  ) {
     const userJwt = this.jwtService.sign(
       { email },
       {
@@ -24,9 +27,8 @@ export class AuthLinkGeneratorService {
       }
     );
     const confirmationLink = `${this.createOriginFromHost(host) ||
-      process.env.DEFAULT_GATEKEEPER_ORIGIN}${
-      path
-    }/?user=${userJwt}&r=${redirectLink}`;
+      process.env
+        .DEFAULT_GATEKEEPER_ORIGIN}${path}/?user=${userJwt}&r=${redirectLink}`;
     return encodeURI(confirmationLink);
   }
-};
+}

--- a/src/auth/auth-link-generator.service.ts
+++ b/src/auth/auth-link-generator.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from "@nestjs/common";
+import { JwtService } from "@nestjs/jwt";
+
+@Injectable()
+export class AuthLinkGeneratorService {
+  constructor(
+    private readonly jwtService: JwtService
+  ) {}
+
+  private createOriginFromHost(host: string) {
+    if (host.startsWith("https://") || host.startsWith("http://")) return host;
+    let scheme = "https";
+    if (host.startsWith("localhost")) {
+      scheme = "http";
+    }
+    return `${scheme}://${host}`;
+  }
+
+  getLinkWithUserJwt(email: string, host: string, path: string = "/", redirectLink: string) {
+    const userJwt = this.jwtService.sign(
+      { email },
+      {
+        expiresIn: process.env.CONFIRMATION_JWT_EXPIRATION
+      }
+    );
+    const confirmationLink = `${this.createOriginFromHost(host) ||
+      process.env.DEFAULT_GATEKEEPER_ORIGIN}${
+      path
+    }/?user=${userJwt}&r=${redirectLink}`;
+    return encodeURI(confirmationLink);
+  }
+};

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -9,6 +9,7 @@ import { GoogleStrategy } from "./strategies/google.strategy";
 import { FacebookStrategy } from "./strategies/facebook.strategy";
 import { JwtStrategy } from "./strategies/jwt.strategy";
 import { UserModule } from "../user/user.module";
+import { AuthLinkGeneratorService } from "./auth-link-generator.service";
 
 @Module({
   imports: [
@@ -24,12 +25,13 @@ import { UserModule } from "../user/user.module";
   ],
   providers: [
     AuthService,
+    AuthLinkGeneratorService,
     LocalStrategy,
     LocalSerializer,
     JwtStrategy,
     GoogleStrategy,
     FacebookStrategy
   ],
-  exports: [PassportModule, AuthService]
+  exports: [PassportModule, AuthService, AuthLinkGeneratorService]
 })
 export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -97,7 +97,6 @@ export class AuthService {
    * @param {} res The request response object to attach the JWT to
    */
   async authorizeUser(user: User, res) {
-    console.log(user);
     const userAuth = await this.userAuthService.findById(user.authId);
     if (!userAuth)
       throw new UnauthorizedException("UserAuth does not exist for user");

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -97,6 +97,7 @@ export class AuthService {
    * @param {} res The request response object to attach the JWT to
    */
   async authorizeUser(user: User, res) {
+    console.log(user);
     const userAuth = await this.userAuthService.findById(user.authId);
     if (!userAuth)
       throw new UnauthorizedException("UserAuth does not exist for user");

--- a/src/common/pipe/validation.pipe.ts
+++ b/src/common/pipe/validation.pipe.ts
@@ -10,7 +10,6 @@ import { plainToClass } from "class-transformer";
 @Injectable()
 export class ValidationPipe implements PipeTransform<any> {
   async transform(value: any, { metatype }: ArgumentMetadata) {
-    console.log(value);
     if (!metatype || !this.toValidate(metatype)) {
       return value;
     }

--- a/src/login/login.module.ts
+++ b/src/login/login.module.ts
@@ -9,6 +9,6 @@ import { AuthModule } from "../auth/auth.module";
 })
 export class LoginModule {
   configure(consumer: MiddlewareConsumer) {
-    consumer.apply(saveRedirectParam).forRoutes("login/google$");
+    consumer.apply(saveRedirectParam).forRoutes("login/google$", "login/facebook$");
   }
 }

--- a/src/login/login.module.ts
+++ b/src/login/login.module.ts
@@ -9,6 +9,8 @@ import { AuthModule } from "../auth/auth.module";
 })
 export class LoginModule {
   configure(consumer: MiddlewareConsumer) {
-    consumer.apply(saveRedirectParam).forRoutes("login/google$", "login/facebook$");
+    consumer
+      .apply(saveRedirectParam)
+      .forRoutes("login/google$", "login/facebook$");
   }
 }

--- a/src/mail/templates/reset-password.ejs
+++ b/src/mail/templates/reset-password.ejs
@@ -1,0 +1,55 @@
+<html>
+<div
+    style="max-width:800px; background-color: #18125b; z-index: -1; position: absolute; top: 0; left: 0; padding: 20px">
+
+    <div style="font-family: Questrial, sans-serif;
+				background: #fff;
+				box-shadow: 0px 10px 10px rgba(0, 0, 0, 0.1);
+				border-radius: 3px;
+				padding: 20px 50px !important;
+				max-width: 500px;
+				display: block;
+				margin: 20px auto;">
+        <h2 style="margin-bottom: 20px; font-size: 14px; color: black">Hi there!</h2>
+
+        <p style="line-height: 20px; -webkit-font-smoothing: antialiased;
+				  font-weight: normal;
+				  color: black;
+				  margin-bottom: 20px;">
+            We understand that you're trying to reset your password. Please click the button below to proceed.
+        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+            <tr>
+                <td align="center">
+                    <div style="margin: 3em 0em;">
+                        <a style="padding: 1em 2em;
+                                    background-color: #4740af; 
+                                    border-radius: 5px;
+                                    text-decoration: none;
+                                    font-weight: bold;
+                                    color: white;" target="_blank" href="<%= locals.resetPasswordLink %>">
+                            Reset Password
+                        </a>
+                    </div>
+                </td>
+            </tr>
+        </table>
+        
+        </p>
+
+        <h3 style=" margin-bottom: 5px;
+				    font-size: 14px;
+				    line-height: 30px;
+				    -webkit-font-smoothing: antialiased;
+				    font-weight: normal;">
+            Thanks!
+        </h3>
+
+        <strong style=" color: #18125b;
+						font-size: 14px;">
+            The TAMU Datathon Team
+        </strong>
+
+    </div>
+</div>
+
+</html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,7 @@ async function bootstrap(): Promise<void> {
   // Use session level CRSF for better protection. (only on login and signup endpoints)
   app.use("/login", csrf());
   app.use("/signup", csrf());
+  app.use("/reset-password", csrf());
 
   app.useStaticAssets(join(__dirname, "..", "public"));
   app.setBaseViewsDir(join(__dirname, "..", "views"));

--- a/src/reset-password/reset-password.controller.spec.ts
+++ b/src/reset-password/reset-password.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ResetPasswordController } from './reset-password.controller';
+
+describe('ResetPassword Controller', () => {
+  let controller: ResetPasswordController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ResetPasswordController],
+    }).compile();
+
+    controller = module.get<ResetPasswordController>(ResetPasswordController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/reset-password/reset-password.controller.spec.ts
+++ b/src/reset-password/reset-password.controller.spec.ts
@@ -1,12 +1,21 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { ResetPasswordController } from "./reset-password.controller";
+import { ValidatorService } from "../validator/validator.service";
+import { ResetPasswordService } from "./reset-password.service";
 
 describe("ResetPassword Controller", () => {
   let controller: ResetPasswordController;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      controllers: [ResetPasswordController]
+      controllers: [ResetPasswordController],
+      providers: [
+        {
+          provide: ResetPasswordService,
+          useValue: {}
+        },
+        ValidatorService
+      ]
     }).compile();
 
     controller = module.get<ResetPasswordController>(ResetPasswordController);

--- a/src/reset-password/reset-password.controller.spec.ts
+++ b/src/reset-password/reset-password.controller.spec.ts
@@ -2,9 +2,49 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { ResetPasswordController } from "./reset-password.controller";
 import { ValidatorService } from "../validator/validator.service";
 import { ResetPasswordService } from "./reset-password.service";
+import { GatekeeperGalaxyIntegration } from "../galaxy-integrations/galaxy-integrations";
+import { NotFoundException } from "@nestjs/common";
+import { AuthProviderException } from "../auth/exceptions/auth-provider.exception";
+import { UserAuth } from "../user-auth/interfaces/user-auth.interface";
+
+class MockResetPasswordService {
+  async handleResetPasswordRequest() {
+    /* Should be overriden using spyOn */
+  }
+
+  async validateResetPasswordRequest() {
+    /* Should be overriden using spyOn */
+  }
+
+  async resetPassword() {
+    /* Should be overriden using spyOn */
+  }
+}
+
+const mockCsrfToken = "test-csrf";
+const mockCsrfGenerator = (): string => mockCsrfToken;
+const csrfReq = {
+  csrfToken: mockCsrfGenerator
+};
+const response = {
+  code: 200,
+  render: (path, params): Record<string, any> => {
+    return { path, params };
+  },
+  status: (statusCode: number) => {
+    response.code = statusCode;
+    return response;
+  },
+  new: () => {
+    // Reset the state of the response
+    response.code = 200;
+    return response;
+  }
+};
 
 describe("ResetPassword Controller", () => {
   let controller: ResetPasswordController;
+  let resetPasswordService: ResetPasswordService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -12,16 +52,217 @@ describe("ResetPassword Controller", () => {
       providers: [
         {
           provide: ResetPasswordService,
-          useValue: {}
+          useValue: new MockResetPasswordService()
         },
         ValidatorService
       ]
     }).compile();
 
     controller = module.get<ResetPasswordController>(ResetPasswordController);
+    resetPasswordService = module.get<ResetPasswordService>(
+      ResetPasswordService
+    );
   });
 
   it("should be defined", () => {
     expect(controller).toBeDefined();
+  });
+
+  it("should return a root page with a csrfToken & redirectLink", () => {
+    const result = controller.root(
+      csrfReq,
+      "/apply/status",
+      GatekeeperGalaxyIntegration
+    );
+    expect(result.csrfToken).toBe(mockCsrfToken);
+    expect(result.redirectLink).toBe("/apply/status");
+  });
+
+  it("should return a reset-password-link-sent page on a successful reset-password request", async () => {
+    jest
+      .spyOn(resetPasswordService, "handleResetPasswordRequest")
+      .mockImplementation(async () => {
+        return;
+      });
+
+    const { path, params } = await controller.sendResetPasswordLink(
+      csrfReq,
+      "testy@mctestface.com",
+      "/apply/status",
+      "localhost",
+      GatekeeperGalaxyIntegration,
+      response.new()
+    );
+    expect(path).toBe("reset-password/reset-password-link-sent");
+    expect(params.userEmail).toBe("testy@mctestface.com");
+  });
+
+  it("should return the reset-password page with an email error if user doesn't exist", async () => {
+    jest
+      .spyOn(resetPasswordService, "handleResetPasswordRequest")
+      .mockImplementation(async () => {
+        throw new NotFoundException("Should be in the email error.");
+      });
+
+    const { path, params } = await controller.sendResetPasswordLink(
+      csrfReq,
+      "testy@mctestface.com",
+      "/apply/status",
+      "localhost",
+      GatekeeperGalaxyIntegration,
+      response.new()
+    );
+    expect(path).toBe("reset-password/index");
+    expect(params.csrfToken).toBe(mockCsrfToken);
+    expect(params.redirectLink).toBe("/apply/status");
+    expect(params.emailPrefill).toBe("testy@mctestface.com");
+    expect(params.emailError).toBe("Should be in the email error.");
+  });
+
+  it("should return the reset-password page with an email error if user didn't sign up with email", async () => {
+    jest
+      .spyOn(resetPasswordService, "handleResetPasswordRequest")
+      .mockImplementation(async () => {
+        throw new AuthProviderException("Google", 401);
+      });
+
+    const { path, params } = await controller.sendResetPasswordLink(
+      csrfReq,
+      "testy@mctestface.com",
+      "/apply/status",
+      "localhost",
+      GatekeeperGalaxyIntegration,
+      response.new()
+    );
+    expect(path).toBe("reset-password/index");
+    expect(params.csrfToken).toBe(mockCsrfToken);
+    expect(params.redirectLink).toBe("/apply/status");
+    expect(params.emailPrefill).toBe("testy@mctestface.com");
+    expect(params.emailError).toBe(
+      "The user with the given was created using Google. " +
+        "Passwords cannot be reset for accounts created using Google."
+    );
+  });
+
+  it("should return the reset-password page for a valid reset-password link", async () => {
+    jest
+      .spyOn(resetPasswordService, "validateResetPasswordRequest")
+      .mockImplementation(() => {
+        return "testy@mctestface.com";
+      });
+
+    const { path, params } = await controller.getResetPage(
+      csrfReq,
+      "test-user-jwt",
+      "/apply/application",
+      response.new()
+    );
+    expect(path).toBe("reset-password/reset-page");
+    expect(params.csrfToken).toBe(mockCsrfToken);
+    expect(params.userJwt).toBe("test-user-jwt");
+    expect(params.redirectLink).toBe("/apply/application");
+  });
+
+  it("should return a reset-failure page for an invalid reset-password link", async () => {
+    jest
+      .spyOn(resetPasswordService, "validateResetPasswordRequest")
+      .mockImplementation(() => {
+        throw new Error("JWT is invalid");
+      });
+
+    const { path, params } = await controller.getResetPage(
+      csrfReq,
+      "invalid-user-jwt",
+      "/apply/application",
+      response.new()
+    );
+    expect(path).toBe("reset-password/reset-failure");
+    expect(params.redirectLink).toBe("/apply/application");
+  });
+
+  it("should return a reset-password-success page on a valid reset-password request", async () => {
+    jest
+      .spyOn(resetPasswordService, "resetPassword")
+      .mockImplementation(async () => {
+        return { email: "testy@mctestface.com" } as UserAuth;
+      });
+
+    const { path, params } = await controller.resetPassword(
+      csrfReq,
+      "validPassword123$",
+      "validPassword123$",
+      "valid-user-jwt",
+      "/apply/success",
+      response.new()
+    );
+    expect(path).toBe("reset-password/reset-success");
+    expect(params.redirectLink).toBe("/apply/success");
+  });
+
+  it("should return the reset-password page with an error for an invalid password", async () => {
+    jest
+      .spyOn(resetPasswordService, "resetPassword")
+      .mockImplementation(async () => {
+        return { email: "testy@mctestface.com" } as UserAuth;
+      });
+
+    const { path, params } = await controller.resetPassword(
+      csrfReq,
+      "smol", // Password should be atleast 6 characters to be valid.
+      "smol",
+      "valid-user-jwt",
+      "/apply/success",
+      response.new()
+    );
+    expect(path).toBe("reset-password/reset-page");
+    expect(params.csrfToken).toBe(mockCsrfToken);
+    expect(params.userJwt).toBe("valid-user-jwt");
+    expect(params.redirectLink).toBe("/apply/success");
+    expect(params.passwordError).toBe(
+      "A password must contain at least 6 characters."
+    );
+  });
+
+  it("should return the reset-password page with an error when password & confirmPassword mismatch", async () => {
+    jest
+      .spyOn(resetPasswordService, "resetPassword")
+      .mockImplementation(async () => {
+        return { email: "testy@mctestface.com" } as UserAuth;
+      });
+
+    const { path, params } = await controller.resetPassword(
+      csrfReq,
+      "validPassword123$", // Password should be atleast 6 characters to be valid.
+      "validPasswordButDifferent123$",
+      "valid-user-jwt",
+      "/apply/success",
+      response.new()
+    );
+    expect(path).toBe("reset-password/reset-page");
+    expect(params.csrfToken).toBe(mockCsrfToken);
+    expect(params.userJwt).toBe("valid-user-jwt");
+    expect(params.redirectLink).toBe("/apply/success");
+    expect(params.confirmPasswordError).toBe(
+      "Value must match the given password."
+    );
+  });
+
+  it("should return the reset-failure page for any errors during the password reset", async () => {
+    jest
+      .spyOn(resetPasswordService, "resetPassword")
+      .mockImplementation(async () => {
+        throw new Error("Something went wrong");
+      });
+
+    const { path, params } = await controller.resetPassword(
+      csrfReq,
+      "validPassword123$", // Password should be atleast 6 characters to be valid.
+      "validPassword123$",
+      "valid-user-jwt",
+      "/apply/success",
+      response.new()
+    );
+    expect(path).toBe("reset-password/reset-failure");
+    expect(params.redirectLink).toBe("/apply/success");
   });
 });

--- a/src/reset-password/reset-password.controller.spec.ts
+++ b/src/reset-password/reset-password.controller.spec.ts
@@ -1,18 +1,18 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { ResetPasswordController } from './reset-password.controller';
+import { Test, TestingModule } from "@nestjs/testing";
+import { ResetPasswordController } from "./reset-password.controller";
 
-describe('ResetPassword Controller', () => {
+describe("ResetPassword Controller", () => {
   let controller: ResetPasswordController;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      controllers: [ResetPasswordController],
+      controllers: [ResetPasswordController]
     }).compile();
 
     controller = module.get<ResetPasswordController>(ResetPasswordController);
   });
 
-  it('should be defined', () => {
+  it("should be defined", () => {
     expect(controller).toBeDefined();
   });
 });

--- a/src/reset-password/reset-password.controller.ts
+++ b/src/reset-password/reset-password.controller.ts
@@ -15,7 +15,7 @@ import { GalaxyIntegrationConfig } from "../galaxy-integrations/interfaces/galax
 import { ValidatedHost } from "../common/decorators/validated-host.decorator";
 import { ResetPasswordService } from "./reset-password.service";
 import { AuthProviderException } from "../auth/exceptions/auth-provider.exception";
-import { ValidatorService } from "src/validator/validator.service";
+import { ValidatorService } from "../validator/validator.service";
 
 @Controller("reset-password")
 export class ResetPasswordController {
@@ -116,21 +116,15 @@ export class ResetPasswordController {
       );
       // Validate new password.
       let validationErrors = undefined;
-      if (
-        !password ||
-        !this.validatorService.validatePassword(password)
-      )
+      if (!password || !this.validatorService.validatePassword(password))
         validationErrors = {
-          passwordError: "A password must contain at least 6 characters.",
+          passwordError: "A password must contain at least 6 characters."
         };
-      else if (
-        !confirmPassword ||
-        confirmPassword !== password
-      )
+      else if (!confirmPassword || confirmPassword !== password)
         validationErrors = {
-          confirmPasswordError: "Value must match the given password.",
+          confirmPasswordError: "Value must match the given password."
         };
-  
+
       if (validationErrors)
         return res.status(400).render("reset-password/reset-page", {
           csrfToken: req.csrfToken(),
@@ -142,7 +136,7 @@ export class ResetPasswordController {
 
       await this.resetPaswordService.resetPassword(userEmail, password);
       return res.status(400).render("reset-password/reset-success", {
-        redirectLink,
+        redirectLink
       });
     } catch (e) {
       return res.status(400).render("reset-password/reset-failure", {

--- a/src/reset-password/reset-password.controller.ts
+++ b/src/reset-password/reset-password.controller.ts
@@ -1,0 +1,63 @@
+import { Controller, Get, Render, Req, Post, Body, NotFoundException, Res } from '@nestjs/common';
+import { QueryWithDefault } from 'src/common/decorators/query-with-default.decorator';
+import { RedirectGalaxyIntegration } from 'src/galaxy-integrations/decorators/redirect-galaxy-integration.decorator';
+import { GalaxyIntegrationConfig } from 'src/galaxy-integrations/interfaces/galaxy-integration';
+import { ValidatedHost } from 'src/common/decorators/validated-host.decorator';
+import { ResetPasswordService } from './reset-password.service';
+import { AuthProviderException } from 'src/auth/exceptions/auth-provider.exception';
+
+@Controller('reset-password')
+export class ResetPasswordController {
+  constructor(
+    private resetPaswordService: ResetPasswordService,
+  ) {}
+
+  @Get("/")
+  @Render("reset-password/index")
+  root(
+    @Req() req,
+    @QueryWithDefault("r") redirectLink: string | undefined,
+    @RedirectGalaxyIntegration() integrationConfig: GalaxyIntegrationConfig
+  ) {
+    return {
+      ...integrationConfig,
+      csrfToken: req.csrfToken(),
+      redirectLink
+    };
+  }
+
+  @Post("/")
+  async sendResetPasswordLink(
+    @Req() req,
+    @Body("email") userEmail: string,
+    @QueryWithDefault("r") redirectLink: string | undefined,
+    @ValidatedHost() host: string,
+    @RedirectGalaxyIntegration() integrationConfig: GalaxyIntegrationConfig,
+    @Res() res
+  ) {
+    try {
+      await this.resetPaswordService.sendResetPasswordEmailForUser(userEmail, host, redirectLink);
+      return res.render("reset-password/reset-password-link-sent", {
+        ...integrationConfig,
+        userEmail: userEmail
+      });
+    } catch (e) {
+      if (e instanceof NotFoundException)
+        return res.status(409).render("reset-password/index", {
+          csrfToken: req.csrfToken(),
+          redirectLink,
+          emailPrefill: userEmail,
+          emailError: e.message
+        });
+      if (e instanceof AuthProviderException)
+        return res.status(409).render("reset-password/index", {
+          csrfToken: req.csrfToken(),
+          redirectLink,
+          emailPrefill: userEmail,
+          emailError: `The user with the given was created using ${e.message}. Passwords cannot be reset for accounts created using ${e.message}.`
+        });
+        
+      throw e;
+    }
+  }
+}

--- a/src/reset-password/reset-password.controller.ts
+++ b/src/reset-password/reset-password.controller.ts
@@ -1,16 +1,23 @@
-import { Controller, Get, Render, Req, Post, Body, NotFoundException, Res } from '@nestjs/common';
-import { QueryWithDefault } from 'src/common/decorators/query-with-default.decorator';
-import { RedirectGalaxyIntegration } from 'src/galaxy-integrations/decorators/redirect-galaxy-integration.decorator';
-import { GalaxyIntegrationConfig } from 'src/galaxy-integrations/interfaces/galaxy-integration';
-import { ValidatedHost } from 'src/common/decorators/validated-host.decorator';
-import { ResetPasswordService } from './reset-password.service';
-import { AuthProviderException } from 'src/auth/exceptions/auth-provider.exception';
+import {
+  Controller,
+  Get,
+  Render,
+  Req,
+  Post,
+  Body,
+  NotFoundException,
+  Res
+} from "@nestjs/common";
+import { QueryWithDefault } from "../common/decorators/query-with-default.decorator";
+import { RedirectGalaxyIntegration } from "../galaxy-integrations/decorators/redirect-galaxy-integration.decorator";
+import { GalaxyIntegrationConfig } from "../galaxy-integrations/interfaces/galaxy-integration";
+import { ValidatedHost } from "../common/decorators/validated-host.decorator";
+import { ResetPasswordService } from "./reset-password.service";
+import { AuthProviderException } from "../auth/exceptions/auth-provider.exception";
 
-@Controller('reset-password')
+@Controller("reset-password")
 export class ResetPasswordController {
-  constructor(
-    private resetPaswordService: ResetPasswordService,
-  ) {}
+  constructor(private resetPaswordService: ResetPasswordService) {}
 
   @Get("/")
   @Render("reset-password/index")
@@ -36,7 +43,11 @@ export class ResetPasswordController {
     @Res() res
   ) {
     try {
-      await this.resetPaswordService.sendResetPasswordEmailForUser(userEmail, host, redirectLink);
+      await this.resetPaswordService.sendResetPasswordEmailForUser(
+        userEmail,
+        host,
+        redirectLink
+      );
       return res.render("reset-password/reset-password-link-sent", {
         ...integrationConfig,
         userEmail: userEmail
@@ -56,7 +67,7 @@ export class ResetPasswordController {
           emailPrefill: userEmail,
           emailError: `The user with the given was created using ${e.message}. Passwords cannot be reset for accounts created using ${e.message}.`
         });
-        
+
       throw e;
     }
   }

--- a/src/reset-password/reset-password.controller.ts
+++ b/src/reset-password/reset-password.controller.ts
@@ -140,9 +140,11 @@ export class ResetPasswordController {
           ...validationErrors
         });
 
-      
+      await this.resetPaswordService.resetPassword(userEmail, password);
+      return res.status(400).render("reset-password/reset-success", {
+        redirectLink,
+      });
     } catch (e) {
-      console.log(e);
       return res.status(400).render("reset-password/reset-failure", {
         redirectLink
       });

--- a/src/reset-password/reset-password.controller.ts
+++ b/src/reset-password/reset-password.controller.ts
@@ -48,7 +48,7 @@ export class ResetPasswordController {
     @Res() res
   ) {
     try {
-      await this.resetPaswordService.sendResetPasswordEmailForUser(
+      await this.resetPaswordService.handleResetPasswordRequest(
         userEmail,
         host,
         redirectLink
@@ -85,12 +85,9 @@ export class ResetPasswordController {
     @Res() res
   ) {
     try {
-      const userEmail = await this.resetPaswordService.validateResetPasswordRequest(
-        userJwt
-      );
+      this.resetPaswordService.validateResetPasswordRequest(userJwt);
       return res.render("reset-password/reset-page", {
         csrfToken: req.csrfToken(),
-        userEmail,
         userJwt,
         redirectLink
       });
@@ -111,9 +108,6 @@ export class ResetPasswordController {
     @Res() res
   ) {
     try {
-      const userEmail = await this.resetPaswordService.validateResetPasswordRequest(
-        userJwt
-      );
       // Validate new password.
       let validationErrors = undefined;
       if (!password || !this.validatorService.validatePassword(password))
@@ -130,11 +124,10 @@ export class ResetPasswordController {
           csrfToken: req.csrfToken(),
           redirectLink,
           userJwt,
-          userEmail,
           ...validationErrors
         });
 
-      await this.resetPaswordService.resetPassword(userEmail, password);
+      await this.resetPaswordService.resetPassword(userJwt, password);
       return res.status(400).render("reset-password/reset-success", {
         redirectLink
       });

--- a/src/reset-password/reset-password.module.ts
+++ b/src/reset-password/reset-password.module.ts
@@ -1,10 +1,10 @@
-import { Module } from '@nestjs/common';
-import { AuthModule } from 'src/auth/auth.module';
-import { JwtModule, JwtModuleOptions } from '@nestjs/jwt';
-import { ResetPasswordController } from './reset-password.controller';
-import { ResetPasswordService } from './reset-password.service';
-import { UserAuthModule } from 'src/user-auth/user-auth.module';
-import { MailModule } from 'src/mail/mail.module';
+import { Module } from "@nestjs/common";
+import { AuthModule } from "../auth/auth.module";
+import { JwtModule, JwtModuleOptions } from "@nestjs/jwt";
+import { ResetPasswordController } from "./reset-password.controller";
+import { ResetPasswordService } from "./reset-password.service";
+import { UserAuthModule } from "../user-auth/user-auth.module";
+import { MailModule } from "../mail/mail.module";
 
 @Module({
   imports: [

--- a/src/reset-password/reset-password.module.ts
+++ b/src/reset-password/reset-password.module.ts
@@ -5,6 +5,7 @@ import { ResetPasswordController } from "./reset-password.controller";
 import { ResetPasswordService } from "./reset-password.service";
 import { UserAuthModule } from "../user-auth/user-auth.module";
 import { MailModule } from "../mail/mail.module";
+import { ValidatorService } from "src/validator/validator.service";
 
 @Module({
   imports: [
@@ -19,6 +20,6 @@ import { MailModule } from "../mail/mail.module";
     })
   ],
   controllers: [ResetPasswordController],
-  providers: [ResetPasswordService]
+  providers: [ResetPasswordService, ValidatorService]
 })
 export class ResetPasswordModule {}

--- a/src/reset-password/reset-password.module.ts
+++ b/src/reset-password/reset-password.module.ts
@@ -5,7 +5,7 @@ import { ResetPasswordController } from "./reset-password.controller";
 import { ResetPasswordService } from "./reset-password.service";
 import { UserAuthModule } from "../user-auth/user-auth.module";
 import { MailModule } from "../mail/mail.module";
-import { ValidatorService } from "src/validator/validator.service";
+import { ValidatorService } from "../validator/validator.service";
 
 @Module({
   imports: [

--- a/src/reset-password/reset-password.module.ts
+++ b/src/reset-password/reset-password.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from 'src/auth/auth.module';
+import { JwtModule, JwtModuleOptions } from '@nestjs/jwt';
+import { ResetPasswordController } from './reset-password.controller';
+import { ResetPasswordService } from './reset-password.service';
+import { UserAuthModule } from 'src/user-auth/user-auth.module';
+import { MailModule } from 'src/mail/mail.module';
+
+@Module({
+  imports: [
+    AuthModule,
+    UserAuthModule,
+    MailModule,
+    JwtModule.registerAsync({
+      // Needs to be async as it uses env variable that's loaded after module is registered.
+      useFactory: (): JwtModuleOptions => ({
+        secret: process.env.AUTH_JWT_SECRET
+      })
+    })
+  ],
+  controllers: [ResetPasswordController],
+  providers: [ResetPasswordService]
+})
+export class ResetPasswordModule {}

--- a/src/reset-password/reset-password.service.spec.ts
+++ b/src/reset-password/reset-password.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ResetPasswordService } from './reset-password.service';
+
+describe('ResetPasswordService', () => {
+  let service: ResetPasswordService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ResetPasswordService],
+    }).compile();
+
+    service = module.get<ResetPasswordService>(ResetPasswordService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/reset-password/reset-password.service.spec.ts
+++ b/src/reset-password/reset-password.service.spec.ts
@@ -26,11 +26,9 @@ describe("ResetPasswordService", () => {
         },
         {
           provide: AuthLinkGeneratorService,
-          useValue: {
-
-          }
+          useValue: {}
         }
-      ],
+      ]
     }).compile();
 
     service = module.get<ResetPasswordService>(ResetPasswordService);

--- a/src/reset-password/reset-password.service.spec.ts
+++ b/src/reset-password/reset-password.service.spec.ts
@@ -1,12 +1,36 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { ResetPasswordService } from "./reset-password.service";
+import { UserAuthService } from "../user-auth/user-auth.service";
+import { JwtModule } from "@nestjs/jwt";
+import { MailService } from "../mail/mail.service";
+import { MailCoreService } from "../mail/mail-core.service";
+import { MockMailCoreService } from "../mail/mocks/mock-mail-core.service";
+import { AuthLinkGeneratorService } from "../auth/auth-link-generator.service";
 
 describe("ResetPasswordService", () => {
   let service: ResetPasswordService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ResetPasswordService]
+      imports: [JwtModule.register({ secret: "TEST_SECRET" })],
+      providers: [
+        ResetPasswordService,
+        {
+          provide: UserAuthService,
+          useValue: {}
+        },
+        MailService,
+        {
+          provide: MailCoreService,
+          useValue: new MockMailCoreService()
+        },
+        {
+          provide: AuthLinkGeneratorService,
+          useValue: {
+
+          }
+        }
+      ],
     }).compile();
 
     service = module.get<ResetPasswordService>(ResetPasswordService);

--- a/src/reset-password/reset-password.service.spec.ts
+++ b/src/reset-password/reset-password.service.spec.ts
@@ -69,11 +69,9 @@ describe("ResetPasswordService", () => {
   });
 
   it("should fail when trying to reset password for a non-existent user", async () => {
-    jest
-      .spyOn(userAuthService, "findByEmail")
-      .mockImplementation(async () => {
-        return null;
-      });
+    jest.spyOn(userAuthService, "findByEmail").mockImplementation(async () => {
+      return null;
+    });
 
     const promise = service.handleResetPasswordRequest(
       "test@mctestface.com",

--- a/src/reset-password/reset-password.service.spec.ts
+++ b/src/reset-password/reset-password.service.spec.ts
@@ -1,14 +1,30 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { ResetPasswordService } from "./reset-password.service";
 import { UserAuthService } from "../user-auth/user-auth.service";
-import { JwtModule } from "@nestjs/jwt";
+import { JwtModule, JwtService } from "@nestjs/jwt";
 import { MailService } from "../mail/mail.service";
 import { MailCoreService } from "../mail/mail-core.service";
 import { MockMailCoreService } from "../mail/mocks/mock-mail-core.service";
 import { AuthLinkGeneratorService } from "../auth/auth-link-generator.service";
+import { UserAuth } from "../user-auth/interfaces/user-auth.interface";
+import { NotFoundException } from "@nestjs/common";
+import { AuthProviderException } from "../auth/exceptions/auth-provider.exception";
+
+class MockUserAuthService {
+  async findByEmail() {
+    /* Should be overriden using spyOn */
+  }
+
+  async updatePasswordForUser() {
+    /* Should be overriden using spyOn */
+  }
+}
 
 describe("ResetPasswordService", () => {
   let service: ResetPasswordService;
+  let userAuthService: UserAuthService;
+  let mailService: MailService;
+  let jwtService: JwtService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -17,21 +33,158 @@ describe("ResetPasswordService", () => {
         ResetPasswordService,
         {
           provide: UserAuthService,
-          useValue: {}
+          useValue: new MockUserAuthService()
         },
         MailService,
         {
           provide: MailCoreService,
           useValue: new MockMailCoreService()
         },
-        {
-          provide: AuthLinkGeneratorService,
-          useValue: {}
-        }
+        AuthLinkGeneratorService
       ]
     }).compile();
 
     service = module.get<ResetPasswordService>(ResetPasswordService);
+    userAuthService = module.get<UserAuthService>(UserAuthService);
+    mailService = module.get<MailService>(MailService);
+    jwtService = module.get<JwtService>(JwtService);
+  });
+
+  it("should send a valid user a reset-password email", async () => {
+    jest
+      .spyOn(userAuthService, "findByEmail")
+      .mockImplementation(async email => {
+        return { email, authType: "EmailAndPassword" } as UserAuth;
+      });
+    const sendEmailFunc = jest.spyOn(mailService, "sendTemplatedEmail");
+
+    // Implicitly expect for handleResetPasswordRequest() to not throw an error.
+    await service.handleResetPasswordRequest(
+      "test@mctestface.com",
+      "localhost",
+      "/apply/status"
+    );
+
+    expect(sendEmailFunc).toBeCalled();
+  });
+
+  it("should fail when trying to reset password for a non-existent user", async () => {
+    jest
+      .spyOn(userAuthService, "findByEmail")
+      .mockImplementation(async () => {
+        return null;
+      });
+
+    const promise = service.handleResetPasswordRequest(
+      "test@mctestface.com",
+      "localhost",
+      "/apply/status"
+    );
+
+    await expect(promise).rejects.toThrow(
+      new NotFoundException("A user with the given email does not exist.")
+    );
+  });
+
+  it("should fail when trying to reset password when user's AuthType isn't EmailAndPassword", async () => {
+    jest
+      .spyOn(userAuthService, "findByEmail")
+      .mockImplementation(async email => {
+        return { email, authType: "Facebook" } as UserAuth;
+      });
+
+    const promise = service.handleResetPasswordRequest(
+      "test@mctestface.com",
+      "localhost",
+      "/apply/status"
+    );
+
+    await expect(promise).rejects.toThrow(
+      new AuthProviderException("Facebook", 401)
+    );
+  });
+
+  it("should successfully validate a valid reset-password request", async () => {
+    const userJwt = jwtService.sign(
+      { email: "testy@mctestface.com" },
+      { expiresIn: "1h" }
+    );
+
+    const email = await service.validateResetPasswordRequest(userJwt);
+    expect(email).toBe("testy@mctestface.com");
+  });
+
+  it("should fail validation when given an invalid reset-password request", async () => {
+    const userJwt = jwtService.sign(
+      { email: "testy@mctestface.com" },
+      { expiresIn: "1h" }
+    );
+
+    // Modify userJwt to make it invalid.
+    const func = () =>
+      service.validateResetPasswordRequest(userJwt + "thisisrandom");
+    expect(func).toThrowError();
+  });
+
+  it("should fail validation when given an expired reset-password request", async () => {
+    const userJwt = jwtService.sign(
+      { email: "testy@mctestface.com" },
+      { expiresIn: "0s" }
+    );
+
+    const func = () => service.validateResetPasswordRequest(userJwt);
+    expect(func).toThrowError();
+  });
+
+  it("should successfully reset the password for a valid user", async () => {
+    jest
+      .spyOn(userAuthService, "updatePasswordForUser")
+      .mockImplementation(async email => {
+        return { email } as UserAuth;
+      });
+    const userJwt = jwtService.sign(
+      { email: "testy@mctestface.com" },
+      { expiresIn: "1h" }
+    );
+
+    const user = await service.resetPassword(
+      userJwt,
+      "the-magnificent-password"
+    );
+
+    expect(user.email).toBe("testy@mctestface.com");
+  });
+
+  it("should fail to reset the password with an invalid request JWT", async () => {
+    const userJwt = jwtService.sign(
+      { email: "testy@mctestface.com" },
+      { expiresIn: "1h" }
+    );
+
+    // Modify userJwt to make it invalid.
+    const promise = service.resetPassword(
+      userJwt + "this-is-random",
+      "the-magnificent-password"
+    );
+
+    await expect(promise).rejects.toThrowError();
+  });
+
+  it("should propagate any errors thrown by UserAuthService when trying to reset password", async () => {
+    jest
+      .spyOn(userAuthService, "updatePasswordForUser")
+      .mockImplementation(async () => {
+        throw new Error();
+      });
+    const userJwt = jwtService.sign(
+      { email: "testy@mctestface.com" },
+      { expiresIn: "1h" }
+    );
+
+    // Modify userJwt to make it invalid.
+    const promise = service.resetPassword(userJwt, "the-magnificent-password");
+
+    await expect(promise).rejects.toThrowError();
   });
 
   it("should be defined", () => {

--- a/src/reset-password/reset-password.service.spec.ts
+++ b/src/reset-password/reset-password.service.spec.ts
@@ -1,18 +1,18 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { ResetPasswordService } from './reset-password.service';
+import { Test, TestingModule } from "@nestjs/testing";
+import { ResetPasswordService } from "./reset-password.service";
 
-describe('ResetPasswordService', () => {
+describe("ResetPasswordService", () => {
   let service: ResetPasswordService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ResetPasswordService],
+      providers: [ResetPasswordService]
     }).compile();
 
     service = module.get<ResetPasswordService>(ResetPasswordService);
   });
 
-  it('should be defined', () => {
+  it("should be defined", () => {
     expect(service).toBeDefined();
   });
 });

--- a/src/reset-password/reset-password.service.ts
+++ b/src/reset-password/reset-password.service.ts
@@ -49,4 +49,17 @@ export class ResetPasswordService {
       throw new AuthProviderException(user.authType, 401);
     return this.sendResetPasswordEmail(email, host, redirectLink);
   }
+
+  async validateResetPasswordRequest(
+    userJwt: string
+  ) {
+    const { email } = this.jwtService.verify(userJwt); // Verify returns jwt payload and fails if JWT is invalid.
+    return email;
+  }
+
+  async resetPassword(
+    userEmailL: string,
+    newPassword: string
+  ) {
+  }
 }

--- a/src/reset-password/reset-password.service.ts
+++ b/src/reset-password/reset-password.service.ts
@@ -58,8 +58,9 @@ export class ResetPasswordService {
   }
 
   async resetPassword(
-    userEmailL: string,
-    newPassword: string
+    email: string,
+    password: string
   ) {
+    return this.userAuthService.updatePasswordForUser(email, password);
   }
 }

--- a/src/reset-password/reset-password.service.ts
+++ b/src/reset-password/reset-password.service.ts
@@ -1,0 +1,45 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { AuthLinkGeneratorService } from 'src/auth/auth-link-generator.service';
+import { MailService } from 'src/mail/mail.service';
+import { UserAuthService } from 'src/user-auth/user-auth.service';
+import { AuthProviderException } from 'src/auth/exceptions/auth-provider.exception';
+
+@Injectable()
+export class ResetPasswordService {
+  private readonly resetPasswordPath = "/auth/reset-password/reset";
+  constructor(
+    private userAuthService: UserAuthService,
+    private mailService: MailService,
+    private readonly jwtService: JwtService,
+    private authLinkGeneratorService: AuthLinkGeneratorService
+  ) {}
+   
+  private async sendResetPasswordEmail(
+    userEmail: string,
+    host: string,
+    redirectLink: string
+  ): Promise<void> {
+    return this.mailService.sendTemplatedEmail({
+      emailTo: userEmail,
+      subject: "Reset your password",
+      templateFile: "reset-password.ejs",
+      templateParams: {
+        resetPasswordLink: this.authLinkGeneratorService.getLinkWithUserJwt(userEmail, host, this.resetPasswordPath, redirectLink)
+      }
+    });
+  }
+
+  async sendResetPasswordEmailForUser(
+    email: string,
+    host: string,
+    redirectLink: string
+  ) {
+    const user = await this.userAuthService.findByEmail(email);
+    if (!user)
+      throw new NotFoundException("A user with the given email does not exist.");
+    if (user.authType !== "EmailAndPassword")
+      throw new AuthProviderException(user.authType, 401);
+    return this.sendResetPasswordEmail(email, host, redirectLink);
+  }
+}

--- a/src/reset-password/reset-password.service.ts
+++ b/src/reset-password/reset-password.service.ts
@@ -1,9 +1,9 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
-import { JwtService } from '@nestjs/jwt';
-import { AuthLinkGeneratorService } from 'src/auth/auth-link-generator.service';
-import { MailService } from 'src/mail/mail.service';
-import { UserAuthService } from 'src/user-auth/user-auth.service';
-import { AuthProviderException } from 'src/auth/exceptions/auth-provider.exception';
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { JwtService } from "@nestjs/jwt";
+import { AuthLinkGeneratorService } from "../auth/auth-link-generator.service";
+import { MailService } from "../mail/mail.service";
+import { UserAuthService } from "../user-auth/user-auth.service";
+import { AuthProviderException } from "../auth/exceptions/auth-provider.exception";
 
 @Injectable()
 export class ResetPasswordService {
@@ -14,7 +14,7 @@ export class ResetPasswordService {
     private readonly jwtService: JwtService,
     private authLinkGeneratorService: AuthLinkGeneratorService
   ) {}
-   
+
   private async sendResetPasswordEmail(
     userEmail: string,
     host: string,
@@ -25,7 +25,12 @@ export class ResetPasswordService {
       subject: "Reset your password",
       templateFile: "reset-password.ejs",
       templateParams: {
-        resetPasswordLink: this.authLinkGeneratorService.getLinkWithUserJwt(userEmail, host, this.resetPasswordPath, redirectLink)
+        resetPasswordLink: this.authLinkGeneratorService.getLinkWithUserJwt(
+          userEmail,
+          host,
+          this.resetPasswordPath,
+          redirectLink
+        )
       }
     });
   }
@@ -37,7 +42,9 @@ export class ResetPasswordService {
   ) {
     const user = await this.userAuthService.findByEmail(email);
     if (!user)
-      throw new NotFoundException("A user with the given email does not exist.");
+      throw new NotFoundException(
+        "A user with the given email does not exist."
+      );
     if (user.authType !== "EmailAndPassword")
       throw new AuthProviderException(user.authType, 401);
     return this.sendResetPasswordEmail(email, host, redirectLink);

--- a/src/reset-password/reset-password.service.ts
+++ b/src/reset-password/reset-password.service.ts
@@ -4,6 +4,7 @@ import { AuthLinkGeneratorService } from "../auth/auth-link-generator.service";
 import { MailService } from "../mail/mail.service";
 import { UserAuthService } from "../user-auth/user-auth.service";
 import { AuthProviderException } from "../auth/exceptions/auth-provider.exception";
+import { UserAuth } from "../user-auth/interfaces/user-auth.interface";
 
 @Injectable()
 export class ResetPasswordService {
@@ -35,11 +36,11 @@ export class ResetPasswordService {
     });
   }
 
-  async sendResetPasswordEmailForUser(
+  async handleResetPasswordRequest(
     email: string,
     host: string,
     redirectLink: string
-  ) {
+  ): Promise<void> {
     const user = await this.userAuthService.findByEmail(email);
     if (!user)
       throw new NotFoundException(
@@ -50,12 +51,13 @@ export class ResetPasswordService {
     return this.sendResetPasswordEmail(email, host, redirectLink);
   }
 
-  async validateResetPasswordRequest(userJwt: string) {
+  validateResetPasswordRequest(userJwt: string): string {
     const { email } = this.jwtService.verify(userJwt); // Verify returns jwt payload and fails if JWT is invalid.
     return email;
   }
 
-  async resetPassword(email: string, password: string) {
+  async resetPassword(userJwt: string, password: string): Promise<UserAuth> {
+    const email = this.validateResetPasswordRequest(userJwt);
     return this.userAuthService.updatePasswordForUser(email, password);
   }
 }

--- a/src/reset-password/reset-password.service.ts
+++ b/src/reset-password/reset-password.service.ts
@@ -50,17 +50,12 @@ export class ResetPasswordService {
     return this.sendResetPasswordEmail(email, host, redirectLink);
   }
 
-  async validateResetPasswordRequest(
-    userJwt: string
-  ) {
+  async validateResetPasswordRequest(userJwt: string) {
     const { email } = this.jwtService.verify(userJwt); // Verify returns jwt payload and fails if JWT is invalid.
     return email;
   }
 
-  async resetPassword(
-    email: string,
-    password: string
-  ) {
+  async resetPassword(email: string, password: string) {
     return this.userAuthService.updatePasswordForUser(email, password);
   }
 }

--- a/src/signup/signup.controller.ts
+++ b/src/signup/signup.controller.ts
@@ -106,7 +106,6 @@ export class SignupController {
           emailError: this.controllerErrors.userExists
         });
 
-      // TODO: Change this to a standard way of handling 5XX errors.
       throw e;
     }
   }

--- a/src/signup/signup.service.spec.ts
+++ b/src/signup/signup.service.spec.ts
@@ -9,6 +9,7 @@ import { JwtService, JwtModule } from "@nestjs/jwt";
 import { UserAuth } from "../user-auth/interfaces/user-auth.interface";
 import { UserService } from "../user/user.service";
 import { User } from "../user/interfaces/user.interface";
+import { AuthLinkGeneratorService } from "../auth/auth-link-generator.service";
 
 class MockUserAuthService {
   async create() {
@@ -52,6 +53,12 @@ describe("SignupService", () => {
         {
           provide: UserService,
           useValue: new MockUserService()
+        },
+        {
+          provide: AuthLinkGeneratorService,
+          useValue: { 
+            async getLinkWithUserJwt() { return ""; }
+          }
         }
       ]
     }).compile();

--- a/src/signup/signup.service.spec.ts
+++ b/src/signup/signup.service.spec.ts
@@ -56,8 +56,10 @@ describe("SignupService", () => {
         },
         {
           provide: AuthLinkGeneratorService,
-          useValue: { 
-            async getLinkWithUserJwt() { return ""; }
+          useValue: {
+            async getLinkWithUserJwt() {
+              return "";
+            }
           }
         }
       ]

--- a/src/signup/signup.service.ts
+++ b/src/signup/signup.service.ts
@@ -6,7 +6,7 @@ import { UserAuth } from "../user-auth/interfaces/user-auth.interface";
 import { MailService } from "../mail/mail.service";
 import { UserService } from "../user/user.service";
 import { User } from "../user/interfaces/user.interface";
-import { AuthLinkGeneratorService } from "src/auth/auth-link-generator.service";
+import { AuthLinkGeneratorService } from "../auth/auth-link-generator.service";
 import { JwtService } from "@nestjs/jwt";
 
 @Injectable()
@@ -30,7 +30,12 @@ export class SignupService {
       subject: "Verify your account!",
       templateFile: "email-confirmation.ejs",
       templateParams: {
-        confirmationLink: this.authLinkGeneratorService.getLinkWithUserJwt(userEmail, host, this.verificationPath, redirectLink)
+        confirmationLink: this.authLinkGeneratorService.getLinkWithUserJwt(
+          userEmail,
+          host,
+          this.verificationPath,
+          redirectLink
+        )
       }
     });
   }

--- a/src/signup/signup.service.ts
+++ b/src/signup/signup.service.ts
@@ -4,9 +4,10 @@ import { SignupUserDto } from "./dto/signup-user.dto";
 import { CreateUserAuthDto } from "../user-auth/dto/create-user-auth.dto";
 import { UserAuth } from "../user-auth/interfaces/user-auth.interface";
 import { MailService } from "../mail/mail.service";
-import { JwtService } from "@nestjs/jwt";
 import { UserService } from "../user/user.service";
 import { User } from "../user/interfaces/user.interface";
+import { AuthLinkGeneratorService } from "src/auth/auth-link-generator.service";
+import { JwtService } from "@nestjs/jwt";
 
 @Injectable()
 export class SignupService {
@@ -15,31 +16,9 @@ export class SignupService {
     private userAuthService: UserAuthService,
     private userService: UserService,
     private mailService: MailService,
-    private readonly jwtService: JwtService
+    private readonly jwtService: JwtService,
+    private authLinkGeneratorService: AuthLinkGeneratorService
   ) {}
-
-  private createOriginFromHost(host: string) {
-    if (host.startsWith("https://") || host.startsWith("http://")) return host;
-    let scheme = "https";
-    if (host.startsWith("localhost")) {
-      scheme = "http";
-    }
-    return `${scheme}://${host}`;
-  }
-
-  getVerificationUrl(email: string, host: string, redirectLink: string) {
-    const userJwt = this.jwtService.sign(
-      { email },
-      {
-        expiresIn: process.env.CONFIRMATION_JWT_EXPIRATION
-      }
-    );
-    const confirmationLink = `${this.createOriginFromHost(host) ||
-      process.env.DEFAULT_GATEKEEPER_ORIGIN}${
-      this.verificationPath
-    }/?user=${userJwt}&r=${redirectLink}`;
-    return encodeURI(confirmationLink);
-  }
 
   private async sendVerificationEmail(
     userEmail: string,
@@ -48,11 +27,11 @@ export class SignupService {
   ): Promise<void> {
     return this.mailService.sendTemplatedEmail({
       emailTo: userEmail,
-      subject: "Activate your account!",
+      subject: "Verify your account!",
       templateFile: "email-confirmation.ejs",
       templateParams: {
-        confirmationLink: this.getVerificationUrl(userEmail, host, redirectLink)
-      } /* TODO: Update when email-confirmation is implemented */
+        confirmationLink: this.authLinkGeneratorService.getLinkWithUserJwt(userEmail, host, this.verificationPath, redirectLink)
+      }
     });
   }
 

--- a/src/user-auth/interfaces/user-auth.interface.ts
+++ b/src/user-auth/interfaces/user-auth.interface.ts
@@ -7,7 +7,7 @@ export interface UserAuth extends Document {
   readonly email: string;
   isVerified: boolean;
   readonly authType: UserAuthType;
-  readonly passwordHash?: string;
+  passwordHash?: string;
   readonly firstName?: string;
   readonly lastName?: string;
   accessId?: string;

--- a/src/user-auth/user-auth.service.ts
+++ b/src/user-auth/user-auth.service.ts
@@ -2,7 +2,8 @@ import { Model } from "mongoose";
 import {
   Injectable,
   BadRequestException,
-  ConflictException
+  ConflictException,
+  NotFoundException
 } from "@nestjs/common";
 import { InjectModel } from "@nestjs/mongoose";
 import { UserAuth } from "./interfaces/user-auth.interface";
@@ -84,5 +85,18 @@ export class UserAuthService {
    */
   async findById(id: string): Promise<UserAuth | undefined> {
     return (await this.userAuthModel.findById(id)) || undefined;
+  }
+
+  /**
+   * Updates the password of the user with the given email
+   */
+  async updatePasswordForUser(email: string, password: string): Promise<UserAuth> {
+    const user = await this.findByEmail(email);
+    if (!user)
+      throw new NotFoundException(
+        "A user with the given email does not exist."
+      );
+    user.passwordHash = await bcrypt.hash(password, 10);
+    return user.save();;
   }
 }

--- a/src/user-auth/user-auth.service.ts
+++ b/src/user-auth/user-auth.service.ts
@@ -90,13 +90,16 @@ export class UserAuthService {
   /**
    * Updates the password of the user with the given email
    */
-  async updatePasswordForUser(email: string, password: string): Promise<UserAuth> {
+  async updatePasswordForUser(
+    email: string,
+    password: string
+  ): Promise<UserAuth> {
     const user = await this.findByEmail(email);
     if (!user)
       throw new NotFoundException(
         "A user with the given email does not exist."
       );
     user.passwordHash = await bcrypt.hash(password, 10);
-    return user.save();;
+    return user.save();
   }
 }

--- a/src/user-auth/user-auth.service.ts
+++ b/src/user-auth/user-auth.service.ts
@@ -89,6 +89,8 @@ export class UserAuthService {
 
   /**
    * Updates the password of the user with the given email
+   * @param  {string} email Email of the user whose password is being changed
+   * @param  {string} password The new password
    */
   async updatePasswordForUser(
     email: string,

--- a/views/login/index.ejs
+++ b/views/login/index.ejs
@@ -43,6 +43,10 @@
     </div>
 
     <div class="text-center mt-3">
+      <a href="/auth/reset-password?r=<%= locals.redirectLink %>">Forgot your password?</a>
+    </div>
+
+    <div class="text-center mt-3">
       <a href="/auth/signup?r=<%= locals.redirectLink %>">Create an account</a>
     </div>
 

--- a/views/reset-password/index.ejs
+++ b/views/reset-password/index.ejs
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html class="AuthFormPage" lang="en">
+<%- include ("../partials/head") %>
+
+<body class="AuthFormPage text-center">
+  <form class="form-signin mx-auto px-3" method="post" action="/auth/reset-password?r=<%= locals.redirectLink %>">
+    <!-- csrf token for integrity :) -->
+    <input type="hidden" name="_csrf" value="<%= csrfToken %>" />
+    <!-- logo/image -->
+    <!-- TODO: change the image link to static image -->
+    <img class="mb-4" src="/auth/static/img/main.png" alt="" width="72" height="72" />
+    <h1 class="h3 mb-3 font-weight-normal">Reset Password</h1>
+
+    <p>Enter your email below and we'll send you a link to reset your password.</p>
+
+    <!-- EMAIL -->
+    <div id="email-input-div" class="text-left form-input-div <%= locals.emailError ? 'input-invalid' : null%>">
+      <label for="loginEmail" class="text-muted">Email</label>
+      <input autofocus id="loginEmail" name="email" value="<%= locals.emailPrefill ? locals.emailPrefill : null %>" />
+      <% if (locals.emailError) { %>
+        <div class="form-invalid-feedback">
+          <i class="fas fa-exclamation-circle"></i>
+          <%= locals.emailError %>
+        </div>
+      <% } %>
+    </div>
+
+    <div id="submit-btn-div"" class="text-center text-left">
+      <button type="submit" class="btn btn-primary btn-block btn-lg mx-auto">Get Reset Password Link</button>
+    </div>
+
+    <div class="text-center mt-3">
+      <a href="/auth/login?r=<%= locals.redirectLink %>">Never mind</a>
+    </div>
+
+    <!-- copyright TD -->
+    <p class="mt-5 mb-3 text-muted text-center">&copy; TAMU Datathon <%= new Date().getFullYear() %></p>
+  </form>
+
+  <%- include ("../partials/scripts") %>
+</body>
+
+</html>

--- a/views/reset-password/index.ejs
+++ b/views/reset-password/index.ejs
@@ -15,8 +15,8 @@
 
     <!-- EMAIL -->
     <div id="email-input-div" class="text-left form-input-div <%= locals.emailError ? 'input-invalid' : null%>">
-      <label for="loginEmail" class="text-muted">Email</label>
-      <input autofocus id="loginEmail" name="email" value="<%= locals.emailPrefill ? locals.emailPrefill : null %>" />
+      <label for="resetPasswordEmail" class="text-muted">Email</label>
+      <input autofocus id="resetPasswordEmail" name="email" value="<%= locals.emailPrefill ? locals.emailPrefill : null %>" />
       <% if (locals.emailError) { %>
         <div class="form-invalid-feedback">
           <i class="fas fa-exclamation-circle"></i>

--- a/views/reset-password/reset-failure.ejs
+++ b/views/reset-password/reset-failure.ejs
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<%- include ("../partials/head") %>
+
+<body class="MessagePage">
+  <div class="container">
+    <div class="row justify-content-center message-box" style="height: 70vh;">
+      <div class="col-sm-10 text-center">
+        <div class="logo">
+          <img src="/auth/static/img/main.png" width="80" height="80" />
+        </div>
+
+        <div class="title">
+          <h1 class="h3 font-weight-normal">Reset Password Failure</h1>
+        </div>
+
+        <div>
+          <p>
+            There was an error in trying to reset your password. 
+            <br/>
+            Please request a new reset link.
+          </p>
+        </div>
+
+        <div class="button">
+          <a class="btn btn-outline-primary" href="/auth/reset-password?r=<%= locals.redirectLink %>">Go to the Reset Password Page</a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <%- include ("../partials/scripts") %>
+</body>
+</html>

--- a/views/reset-password/reset-page.ejs
+++ b/views/reset-password/reset-page.ejs
@@ -12,7 +12,7 @@
     <h1 class="h3 mb-3 font-weight-normal">Reset Password</h1>
 
     <p>
-      You're resetting the password for the email <a href="#"><%= userEmail %></a>.
+      You're resetting the password for your account</a>.
     </br>
       Please enter your new password below:
     </p>

--- a/views/reset-password/reset-page.ejs
+++ b/views/reset-password/reset-page.ejs
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html class="AuthFormPage" lang="en">
+<%- include ("../partials/head") %>
+
+<body class="AuthFormPage text-center">
+  <form class="form-signin mx-auto px-3" method="post" action="/auth/reset-password/reset?user=<%= locals.userJwt %>&r=<%= locals.redirectLink %>">
+    <!-- csrf token for integrity :) -->
+    <input type="hidden" name="_csrf" value="<%= csrfToken %>" />
+    <!-- logo/image -->
+    <!-- TODO: change the image link to static image -->
+    <img class="mb-4" src="/auth/static/img/main.png" alt="" width="72" height="72" />
+    <h1 class="h3 mb-3 font-weight-normal">Reset Password</h1>
+
+    <p>
+      You're resetting the password for the email <a href="#"><%= userEmail %></a>.
+    </br>
+      Please enter your new password below:
+    </p>
+
+    <!-- PASSWORD -->
+    <div class="form-input-div <%= locals.passwordError ? 'input-invalid' : null%>">
+      <label for="resetPasswordPassword" class="text-muted">New Password</label>
+      <input type="password" class="" id="resetPasswordPassword" name="password" />
+      <% if (locals.passwordError) { %>
+        <div class="form-invalid-feedback">
+          <i class="fas fa-exclamation-circle"></i>
+          <%= locals.passwordError %>
+        </div>
+      <% } %>
+    </div>
+
+    <!-- CONFIRM PASSWORD -->
+    <div class="form-input-div <%= locals.confirmPasswordError ? 'input-invalid' : null%>">
+      <label for="resetPasswordConfirmPassword" class="text-muted">Confirm Password</label>
+      <input
+        type="password"
+        id="resetPasswordConfirmPassword"
+        name="confirmPassword"
+      />
+      <% if (locals.confirmPasswordError) { %>
+        <div class="form-invalid-feedback">
+          <i class="fas fa-exclamation-circle"></i>
+          <%= locals.confirmPasswordError %>
+        </div>
+      <% } %>
+    </div>
+
+    <div id="submit-btn-div"" class="text-center text-left">
+      <button type="submit" class="btn btn-primary btn-block btn-lg mx-auto">Reset Password</button>
+    </div>
+
+    <div class="text-center mt-3">
+      <a href="/auth/login?r=<%= locals.redirectLink %>">Never mind</a>
+    </div>
+
+    <!-- copyright TD -->
+    <p class="mt-5 mb-3 text-muted text-center">&copy; TAMU Datathon <%= new Date().getFullYear() %></p>
+  </form>
+
+  <%- include ("../partials/scripts") %>
+</body>
+
+</html>

--- a/views/reset-password/reset-password-link-sent.ejs
+++ b/views/reset-password/reset-password-link-sent.ejs
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<%- include ("../partials/head") %>
+
+<body class="MessagePage">
+  <div class="container">
+    <div class="row justify-content-center message-box" style="height: 70vh;">
+      <div class="col-sm-10 text-center">
+        <div class="logo">
+          <img src="/auth/static/img/main.png" width="80" height="80" />
+        </div>
+  
+        <div class="title">
+          <h1 class="h3 font-weight-normal">Check your email for the reset password link</h1>
+        </div>
+
+        <div>
+          <p>
+            Please check your email (<a href="#"><%= userEmail %></a>) for an email from TAMU Datathon. 
+            <br/>
+            Inside that email is a link that will allow you to reset your account password.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <%- include ("../partials/scripts") %>
+</body>
+</html>

--- a/views/reset-password/reset-success.ejs
+++ b/views/reset-password/reset-success.ejs
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<%- include ("../partials/head") %>
+
+<body class="MessagePage">
+  <div class="container">
+    <div class="row justify-content-center message-box" style="height: 70vh;">
+      <div class="col-sm-10 text-center">
+        <div class="logo">
+          <img src="/auth/static/img/main.png" width="80" height="80" />
+        </div>
+
+        <div class="title">
+          <h1 class="h3 font-weight-normal">Reset Password Successful!</h1>
+        </div>
+
+        <div>
+          <p>
+            Your password has been reset.
+          </br>
+          Please log in with your new password to access you account.
+        </p>
+        </div>
+
+        <div class="button">
+          <a class="btn btn-outline-primary" href="/auth/login?r=<%= locals.redirectLink %>">Go to Login Page</a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <%- include ("../partials/scripts") %>
+</body>
+</html>


### PR DESCRIPTION
Closes #71.

I ended up keeping the UI in line with what we have for other pages, so the front-end for this should be done too. 

**Features:**
* Added a "Forgot your password?" link to login page
* Page first asks for an email and sends a reset link if email is valid, user exists and `authType` is `EmailAndPassword`
  * Shows errors if these requirements are violated
* Reset link redirects them to a page where they need to enter the new password and confirm it
  * Page is only shown if the token in the request is valid, an error is shown otherwise
* On submitting a reset request, the token from the original request is propagated and validated again, and the password is reset
* Finally shows a success page that has a button to take them to the login page
* Also refactored the token-based link generation to another service in the `AuthModule`.